### PR TITLE
Fix a level weight adjustment bug in `delete!`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,6 +79,16 @@ end
     end
 end
 
+@testset "Targeted statistical tests" begin
+    #Issue 8
+    ds = DynamicDiscreteSampler()
+    for i in 1:3
+        push!(ds, i, float(i))
+    end
+    delete!(ds, 2)
+    @test count(rand(ds) == 1 for _ in 1:4000) < 1200 # False positivity rate < 4e-13
+end
+
 # These tests are too slow:
 if "CI" in keys(ENV)
     @testset "Code quality (Aqua.jl)" begin


### PR DESCRIPTION
`significand` was incorrectly computed using the weight of the element at the end of the level containing the deleted item rather than the weight of the delete item itself.

I went ahead and manually inlined the delete! call as the comment advised.

Fixes #8 