### PR TITLE
Use Dictionary instead of Dict for map

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,13 @@ authors = ["Lilith Orion Hafner <lilithhafner@gmail.com> and contributors"]
 version = "0.0.0"
 
 [deps]
+Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
+Dictionaries = "0.4"
 Distributions = "0.25"
 Random = "1.10.0"
 StaticArrays = "1.9.8"


### PR DESCRIPTION
I see better performance than with a dict, on our `h` function

```julia
julia> @benchmark h(10^4) # main
BenchmarkTools.Trial: 3098 samples with 1 evaluation.
 Range (min … max):  1.330 ms …   3.458 ms  ┊ GC (min … max): 0.00% … 44.93%
 Time  (median):     1.591 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.609 ms ± 136.258 μs  ┊ GC (mean ± σ):  1.09% ±  3.19%

               ▂▃▄▅▄█▆▇▇▅▇▅▅▃▃▂▂▁                              
  ▂▂▂▃▃▄▄▄▅▅███████████████████████▇▆▅▅▅▅▄▄▃▃▃▃▃▃▃▃▂▂▂▃▂▂▁▂▂▂ ▅
  1.33 ms         Histogram: frequency by time        2.02 ms <

 Memory estimate: 490.94 KiB, allocs estimate: 2907.

julia> @benchmark h(10^4) # this pr
BenchmarkTools.Trial: 3283 samples with 1 evaluation.
 Range (min … max):  1.251 ms …   3.462 ms  ┊ GC (min … max): 0.00% … 48.38%
 Time  (median):     1.504 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.518 ms ± 125.894 μs  ┊ GC (mean ± σ):  1.02% ±  3.12%

              ▁▁▁▃▆▃▅▅▇▇▇██▅▆▃▄▁▂                              
  ▁▁▁▂▃▂▃▃▄▄▅▅███████████████████▇▅▆▆▅▅▄▄▄▄▃▃▃▂▃▂▂▂▂▂▂▂▂▂▁▁▂▁ ▄
  1.25 ms         Histogram: frequency by time        1.89 ms <

 Memory estimate: 470.12 KiB, allocs estimate: 2905.

```


