### PR TITLE
track the first changed level to reduce the number of levels to update

### DIFF
--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -177,7 +177,7 @@ function set_cum_weights!(ss::SelectionSampler4, ns, reorder)
     p, lastfull = ns.sampled_level_weights, ns.track_info.lastfull
     if reorder
         ns.track_info.reset_order = 0
-        if ns.track_info.reset_distribution == false && issorted(@view(p[1:lastfull]))
+        if !ns.track_info.reset_distribution && issorted(@view(p[1:lastfull]))
             return ss
         end
         @inline reorder_levels(ns, ss, p, lastfull)
@@ -286,7 +286,7 @@ function Base.findnext(x::LinkedListSet3, i::Int)
     y = x.data[j] << k
     y != 0 && return i + leading_zeros(y)
     j2 = findnext(!iszero, x.data, j+1)
-    j2 === nothing && return nothing
+    isnothing(j2) && return nothing
     j2 << 6 + leading_zeros(x.data[j2]) - 18*64
 end
 function Base.findprev(x::LinkedListSet3, i::Int)
@@ -295,7 +295,7 @@ function Base.findprev(x::LinkedListSet3, i::Int)
     y = x.data[j] >> (0x3f - k)
     y != 0 && return i - trailing_zeros(y)
     j2 = findprev(!iszero, x.data, j-1)
-    j2 === nothing && return nothing
+    isnothing(j2) && return nothing
     j2 << 6 - trailing_zeros(x.data[j2]) - 17*64 - 1
 end
 

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -189,7 +189,7 @@ function set_cum_weights!(ss::SelectionSampler4, ns, reorder)
     @inbounds for i in f:lastfull
         ss.p[i] = ss.p[i-1] + p[i]
     end
-    ns.track_info.lastchanged = 1
+    ns.track_info.firstchanged = 1
     return ss
 end
 

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -367,7 +367,7 @@ mutable struct TrackInfo
     lastsampled_idx_in::Int
     least_significant_sampled_level::Int # The level number of the least significant tracked level
     nvalues::Int
-    lastchanged::Int
+    firstchanged::Int
     lastfull::Int
     reset_order::Int
     reset_distribution::Bool

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -183,9 +183,10 @@ function set_cum_weights!(ss::SelectionSampler4, ns, reorder)
         @inline reorder_levels(ns, ss, p, lastfull)
         ns.track_info.lastchanged = 1
     end
-    s = ns.track_info.lastchanged + Int(ns.track_info.lastchanged == 1)
+    firstc = ns.track_info.firstchanged
     ss.p[1] = p[1]
-    @inbounds for i in s:lastfull
+    f = firstc + Int(firstc == 1)
+    @inbounds for i in f:lastfull
         ss.p[i] = ss.p[i-1] + p[i]
     end
     ns.track_info.lastchanged = 1
@@ -493,7 +494,7 @@ end
     ns.entry_info.presence[i] = true
     if level ∉ ns.level_set
         # Log the entry
-        ns.track_info.lastchanged = 1
+        ns.track_info.firstchanged = 1
         ns.entry_info.indices[i] = (level, 1)
 
         # Create a new level (or revive an empty level)
@@ -548,8 +549,8 @@ end
 
         if k != 0 # level is sampled
             ns.sampled_level_weights[k] = flot(wn, level)
-            lastv = ns.track_info.lastchanged
-            ns.track_info.lastchanged = k < lastv ? k : lastv
+            firstc = ns.track_info.firstchanged
+            ns.track_info.firstchanged = k < firstc ? k : firstc
         end
     end
     return ns
@@ -588,7 +589,7 @@ end
     ns.all_levels[l] = (wn, level_sampler)
 
     if isempty(level_sampler) # Remove a level
-        ns.track_info.lastchanged = 1
+        ns.track_info.firstchanged = 1
         delete!(ns.level_set, level)
         ns.all_levels[l] = (zero(UInt128), level_sampler) # Fixup for rounding error
         if k != 0 # Remove a sampled level
@@ -625,8 +626,8 @@ end
         end
     elseif k != 0
         ns.sampled_level_weights[k] = flot(wn, level)
-        lastv = ns.track_info.lastchanged
-        ns.track_info.lastchanged = k < lastv ? k : lastv
+        firstc = ns.track_info.firstchanged
+        ns.track_info.firstchanged = k < firstc ? k : firstc
     end
     return ns
 end

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -250,7 +250,7 @@ function Base.push!(rs::RejectionSampler3, i, x)
     len > length(rs.data) && resize!(rs.data, length(rs.data)+len-1)
     rs.data[len] = (i, x)
     maxwn = rs.track_info.maxw
-    rs.track_info.maxw = x > maxwn ? x : maxwn
+    rs.track_info.maxw = ifelse(x > maxwn, x, maxwn)
     rs
 end
 Base.isempty(rs::RejectionSampler3) = length(rs) == 0 # For testing only
@@ -550,7 +550,7 @@ end
         if k != 0 # level is sampled
             ns.sampled_level_weights[k] = flot(wn, level)
             firstc = ns.track_info.firstchanged
-            ns.track_info.firstchanged = k < firstc ? k : firstc
+            ns.track_info.firstchanged = ifelse(k < firstc, k, firstc)
         end
     end
     return ns
@@ -627,7 +627,7 @@ end
     elseif k != 0
         ns.sampled_level_weights[k] = flot(wn, level)
         firstc = ns.track_info.firstchanged
-        ns.track_info.firstchanged = k < firstc ? k : firstc
+        ns.track_info.firstchanged = ifelse(k < firstc, k, firstc)
     end
     return ns
 end

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -506,8 +506,8 @@ end
         else
             level_indices = ns.level_set_map.indices[level+1075]
             w, level_sampler = ns.all_levels[level_indices[1]]
-            #@assert w == 0
-            #@assert isempty(level_sampler)
+            @assert w == 0
+            @assert isempty(level_sampler)
             push!(level_sampler, i, bucketw)
             ns.all_levels[level_indices[1]] = (sig(x), level_sampler)
             level_indices[1]
@@ -576,12 +576,12 @@ end
     l, k = ns.level_set_map.indices[level+1075]
     w, level_sampler = ns.all_levels[l]
     _i, significand = level_sampler.data[j]
-    #@assert _i == i
+    @assert _i == i
     moved_entry, _ = level_sampler.data[j] = level_sampler.data[level_sampler.track_info.length]
     level_sampler.data[level_sampler.track_info.length] = (0, 0.0)
     level_sampler.track_info.length -= 1
     if moved_entry != i
-        #@assert ns.entry_info.indices[moved_entry] == (level, length(level_sampler)+1)
+        @assert ns.entry_info.indices[moved_entry] == (level, length(level_sampler)+1)
         ns.entry_info.indices[moved_entry] = (level, j)
     end
     wn = w-sig(significand*exp2(level+1))
@@ -607,7 +607,7 @@ end
                     ns.sampled_level_weights[k] = ns.sampled_level_weights[sl_length]
                     ns.sampled_level_weights[sl_length] = 0.0
                     all_index, _l = ns.level_set_map.indices[ns.sampled_level_numbers[k]+1075]
-                    #@assert _l == ns.track_info.lastfull+1
+                    @assert _l == ns.track_info.lastfull+1
                     ns.level_set_map.indices[ns.sampled_level_numbers[k]+1075] = (all_index, k)
                     all_index = ns.level_set_map.indices[ns.sampled_level_numbers[sl_length]+1075][1]
                     ns.level_set_map.indices[ns.sampled_level_numbers[sl_length]+1075] = (all_index, sl_length)
@@ -615,7 +615,7 @@ end
             else # Replace the removed level with the replacement
                 ns_track_info.least_significant_sampled_level = replacement
                 all_index, _zero = ns.level_set_map.indices[replacement+1075]
-                #@assert _zero == 0
+                @assert _zero == 0
                 ns.level_set_map.indices[replacement+1075] = (all_index, k)
                 w, replacement_level = ns.all_levels[all_index]
                 ns.sampled_levels[k] = Int16(all_index)

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -414,8 +414,8 @@ function Base.rand(rng::AbstractRNG, ns::NestedSampler5, n::Integer)
     n < 100 && return [rand(rng, ns) for _ in 1:n]
     lastfull = ns.track_info.lastfull
     full_level_weights = @view(ns.sampled_level_weights[1:lastfull])
-    ws = @view(ns.sampled_level_weights[1:lastfull])
     n_each = rand(rng, Multinomial(n, full_level_weights ./ sum(full_level_weights)))
+    inds = Vector{Int}(undef, n)
     q = 1
     @inbounds for (level, k) in enumerate(n_each)
         bucket = ns.all_levels[Int(ns.sampled_levels[level])][2]

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -189,7 +189,7 @@ function set_cum_weights!(ss::SelectionSampler4, ns, reorder)
     @inbounds for i in f:lastfull
         ss.p[i] = ss.p[i-1] + p[i]
     end
-    ns.track_info.firstchanged = 1
+    ns.track_info.firstchanged = lastfull
     return ss
 end
 

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -181,7 +181,7 @@ function set_cum_weights!(ss::SelectionSampler4, ns, reorder)
             return ss
         end
         @inline reorder_levels(ns, ss, p, lastfull)
-        ns.track_info.lastchanged = 1
+        ns.track_info.firstchanged = 1
     end
     firstc = ns.track_info.firstchanged
     ss.p[1] = p[1]


### PR DESCRIPTION
This makes even more sense now that we try to order them. I see a good improvement in some benchmarks, the overhead seems negligible in the worst case