### PR TITLE
Improve rejection loop slightly

### DIFF
--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -78,7 +78,7 @@ function Random.rand(rng::AbstractRNG, rs::RejectionSampler)
     mask = rs.track_info.mask
     maxw = rs.track_info.maxw
     while true
-        u = rand(rng, Int)
+        u = rand(rng, UInt) % Int
         i = u & mask
         i >= len && continue
         i += 1

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -66,20 +66,20 @@ end
 mutable struct RejectionInfo
     length::Int
     maxw::Float64
-    mask::UInt
+    mask::Int
 end
 struct RejectionSampler
     data::Vector{Tuple{Int, Float64}}
     track_info::RejectionInfo
-    RejectionSampler(i, v) = new([(i, v)], RejectionInfo(1, v, zero(UInt)))
+    RejectionSampler(i, v) = new([(i, v)], RejectionInfo(1, v, 0))
 end
 function Random.rand(rng::AbstractRNG, rs::RejectionSampler)
     len = rs.track_info.length
     mask = rs.track_info.mask
     maxw = rs.track_info.maxw
     while true
-        u = rand(rng, UInt)
-        i = Int(u & mask)
+        u = rand(rng, Int)
+        i = u & mask
         i >= len && continue
         i += 1
         res, x = rs.data[i]
@@ -90,7 +90,7 @@ function Base.push!(rs::RejectionSampler, i, x)
     len = rs.track_info.length += 1
     if len > length(rs.data)
         resize!(rs.data, 2*length(rs.data))
-        rs.track_info.mask = UInt64(1) << Base.top_set_bit(len - 1) - 1
+        rs.track_info.mask = 1 << Base.top_set_bit(len - 1) - 1
     end
     rs.data[len] = (i, x)
     maxwn = rs.track_info.maxw


### PR DESCRIPTION
This is a little better in my test:

```julia
julia> using DynamicDiscreteSamplers, Chairmarks, Random

julia> function setup(rng, indices)
           ds = DynamicDiscreteSampler()
           append!(ds, indices, exp.(randn(rng, length(indices))))
           return ds
       end
setup (generic function with 1 method)

julia> rng = Xoshiro(42)
Xoshiro(0xa379de7eeeb2a4e8, 0x953dccb6b532b3af, 0xf597b8ff8cfd652a, 0xccd7337c571680d1, 0xc90c4a0730db3f7e)

julia> ds = setup(rng, 1:10^7);

julia> @b rand($rng, $ds, 10^4)
455.435 μs (7 allocs: 78.562 KiB) # main
424.407 μs (7 allocs: 78.562 KiB) # pr

julia> @b rand($rng, $ds, 10^4)
434.414 μs (7 allocs: 78.562 KiB) # main
392.006 μs (7 allocs: 78.562 KiB) # pr
```
