### PR TITLE
Do rejection sampling for non-sampled levels

### DIFF
--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -493,7 +493,7 @@ function Base.rand(rng::AbstractRNG, fs::FallBackSampler, ns::NestedSampler, las
         totwnots += flot(wlevel, level)
     end
     totw = totwnots + ns.distribution_over_levels.p[lastfull]
-    r = (totwnots/totw) / (typemax(UInt64)/UPPER_LIMIT)
+    r = (typemax(UInt)/UPPER_LIMIT) * (totwnots/totw)
     rand(rng) > r && return 0
     u = rand(rng)*totwnots
     last = 0

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -492,7 +492,7 @@ function Base.rand(rng::AbstractRNG, fs::FallBackSampler, ns::NestedSampler, las
         level = exponent(level_sampler.data[1][2])
         totwnots += flot(wlevel, level)
     end
-    totw = totwnots + ns.distribution_over_levels[lastfull]    
+    totw = totwnots + ns.distribution_over_levels.p[lastfull]    
     r = (typemax(UInt)/UPPER_LIMIT) * (totwnots/totw)
     rand(rng) > r && return 0
     u = rand(rng)*totwnots

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -492,8 +492,8 @@ function Base.rand(rng::AbstractRNG, fs::FallBackSampler, ns::NestedSampler, las
         level = exponent(level_sampler.data[1][2])
         totwnots += flot(wlevel, level)
     end
-    totw = totwnots + ns.distribution_over_levels.p[lastfull]    
-    r = (typemax(UInt)/UPPER_LIMIT) * (totwnots/totw)
+    totw = totwnots + ns.distribution_over_levels.p[lastfull]
+    r = (totwnots/totw) / (typemax(UInt64)/UPPER_LIMIT)
     rand(rng) > r && return 0
     u = rand(rng)*totwnots
     last = 0

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -5,7 +5,7 @@ export DynamicDiscreteSampler, SamplerIndices
 using Distributions, Random, StaticArrays
 
 const UPPER_LIMIT = 10^12
-const MAX_CUT = typemax(UInt)-UPPER_LIMIT+1
+const MAX_CUT = typemax(UInt64)-UPPER_LIMIT+1
 const RANDF = 2^11/MAX_CUT
 
 @inline sig(x::Float64) = (reinterpret(UInt64, x) & Base.significand_mask(Float64)) + Base.significand_mask(Float64) + 1

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -246,7 +246,7 @@ function Base.rand(rng::AbstractRNG, ns::NestedSampler, n::Integer)
     totw = 0.0
     maxw = 0.0
     nvalues_sampled = 0
-    for i in 1:lastfull
+    @inbounds for i in 1:lastfull
         w = ns.sampled_level_weights[i]
         totw += w
         maxw = ifelse(w > maxw, w, maxw)

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -314,7 +314,7 @@ Base.rand(ns::NestedSampler) = rand(Random.default_rng(), ns)
     else
         level_index = rand(rng, FallBackSampler(), ns, lastfull)
         level_index === 0 && return _rand(rng, ns, u, lastfull, track_info)
-        j, i = rand(rng, ns.all_levels[level_index], randnoreuse)
+        j, i = rand(rng, ns.all_levels[level_index][2], randnoreuse)
         return i
     end
 end

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -259,7 +259,7 @@ function Base.rand(rng::AbstractRNG, ns::NestedSampler, n::Integer)
     n_nots = 0
     ws = @view(ns.sampled_level_weights[1:lastfull])
     if rand(rng) > r
-        totw = sum(flot(sl[1], exponent(sl[2].data[1][2])) for sl in ns.all_levels if !isempty(sl[2]))
+        totw = sum(flot(sl[1], sl[2].level) for sl in ns.all_levels if !isempty(sl[2]))
         pnots = 1-totws/totw
         if rand(rng) > (1 - (pnots^n)) / (1-r)
             n_nots = rand(rng, Truncated(Binomial(n, pnots), 1, n))
@@ -310,7 +310,7 @@ Base.rand(ns::NestedSampler) = rand(Random.default_rng(), ns)
         track_info.reset_distribution = false
     end
     u = rand(rng, UInt64)
-    if u < MAX_CUT 
+    if u < MAX_CUT
         return _rand(rng, ns, u, lastfull, track_info)
     else
         level_index = rand(rng, FallBackSampler(), ns, lastfull)

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -4,7 +4,7 @@ export DynamicDiscreteSampler, SamplerIndices
 
 using Distributions, Random, StaticArrays
 
-const UPPER_LIMIT = 10^12
+const UPPER_LIMIT = Int64(10)^12
 const MAX_CUT = typemax(UInt64)-UPPER_LIMIT+1
 const RANDF = 2^11/MAX_CUT
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,18 +85,12 @@ end
 
 @testset "Targeted statistical tests" begin
     #Issue 8
-    for N in [1, 2, 4, 64, 128]
-        ds = DynamicDiscreteSampler{N}()
-        for i in 1:3
-            push!(ds, i, float(i))
-        end
-        delete!(ds, 2)
-        if N > 1
-            @test 0 < count(rand(ds) == 1 for _ in 1:4000) < 1200 # False positivity rate < 4e-13
-        else
-            @test count(rand(ds) == 1 for _ in 1:4000) == 0
-        end
+    ds = DynamicDiscreteSampler()
+    for i in 1:3
+        push!(ds, i, float(i))
     end
+    delete!(ds, 2)
+    @test 0 < count(rand(ds) == 1 for _ in 1:4000) < 1200 # False positivity rate < 4e-13
 end
   
 @testset "Randomized statistical tests" begin


### PR DESCRIPTION
I actually had some time to spare, and I cooked up this implementation for #40. The impact on performance seems to be near 0.

The idea is to reject initially with probability `UPPER_LIMIT/typemax(UInt64)`, which should be an upper limit of the probability of rejection, then enter the fallback sampler and adjust the probability to match the correct one e.g `tot_weight_of_not_sampled_levels/tot_weight`. 

I also fixed the level to 64 with this, because otherwise the upper limit would not hold with certain numbers of sampled levels.

