### PR TITLE
Improve accuracy of level selection

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,11 +5,13 @@ version = "0.0.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+DoubleFloats = "497a8b3b-efae-58df-a0af-a86822472b78"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 Distributions = "0.25"
+DoubleFloats = "1"
 Random = "1.10.0"
 StaticArrays = "1.9.8"
 julia = "1.10.0"


### PR DESCRIPTION
Alternative to #45.

But actually it is rather slow though, way too much at the moment.

```julia
julia> using DynamicDiscreteSamplers, BenchmarkTools, Random, Statistics

julia> rng = Xoshiro(42);
```

64 levels:

```julia
julia> ds = DynamicDiscreteSampler();

julia> for i in 1:64 push!(ds, i, 2.0^i) end

julia> rand_with_change(rng, ds) = (push!(ds, 65, 2.0); s=rand(rng, ds); delete!(ds, 65); s);

julia> @btime rand($rng, $ds);
  16.665 ns (0 allocations: 0 bytes) #main
  40.712 ns (0 allocations: 0 bytes) #pr

julia> @btime rand_with_change($rng, $ds);
  79.727 ns (0 allocations: 0 bytes)  #main
  236.205 ns (0 allocations: 0 bytes) #pr
```

2 levels:

```julia
julia> ds = DynamicDiscreteSampler();

julia> for i in 1:2 push!(ds, i, 2.0^i) end

julia> rand_with_change(rng, ds) = (push!(ds, 3, 2.0); s=rand(rng, ds); delete!(ds, 3); s);

julia> change_cost(rng, ds) = (push!(ds, 3, 2.0); delete!(ds, 3); ds);

julia> @btime rand($rng, $ds);
  13.659 ns (0 allocations: 0 bytes) #main
  35.586 ns (0 allocations: 0 bytes) #pr

julia> @btime rand_with_change($rng, $ds);
  34.587 ns (0 allocations: 0 bytes) #main
  55.490 ns (0 allocations: 0 bytes) #pr
```




