### PR TITLE
Maintain `m[2]`

### DIFF
--- a/contrib/invariants.jl
+++ b/contrib/invariants.jl
@@ -1,0 +1,12 @@
+function verify_weights(m::Memory)
+    m3 = m[3]
+    for i in 5:2050
+        shift = signed(2051 + m3 - i)
+        weight = m[i]
+        shifted_significand_sum_index = 2041 + 2i
+        shifted_significand_sum = get_UInt128(m, shifted_significand_sum_index)
+        expected_weight = UInt64(shifted_significand_sum<<shift)
+        expected_weight += (trailing_zeros(shifted_significand_sum)+shift < 0) & (shifted_significand_sum != 0)
+        @assert weight == expected_weight
+    end
+end

--- a/contrib/invariants.jl
+++ b/contrib/invariants.jl
@@ -10,3 +10,21 @@ function verify_weights(m::Memory)
         @assert weight == expected_weight
     end
 end
+
+function verify_m2(m::Memory)
+    @assert m[2] == findfirst(i -> i == 2051 || 5 <= i && m[i] != 0, 1:2051)
+end
+function verify_m4(m::Memory)
+    m4 = zero(UInt64)
+    for i in 5:2050
+        m4 = Base.checked_add(m4, m[i])
+    end
+    @assert m[4] == m4
+    @assert m4 == 0 || UInt64(2)^32 <= m4
+end
+
+function verify(m::Memory)
+    verify_weights(m)
+    verify_m2(m)
+    verify_m4(m)
+end

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -1043,7 +1043,7 @@ function FixedSizeWeights(len::Integer)
     m .= 0 # TODO for perf: delete this. It's here so that a sparse rendering for debugging is easier TODO for tests: set this to 0xdeadbeefdeadbeed
     m[4:10491+2len] .= 0 # metadata and edit map need to be zeroed but the bulk does not
     m[1] = len
-    m[2] = 2050
+    m[2] = 2051
     # no need to set m[3]
     m[10235] = 10492+2len
     _FixedSizeWeights(m)

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -873,7 +873,7 @@ function set_global_shift!(m::Memory, m3::UInt, m4=m[4], j0=nothing) # TODO for 
     m3_old = m[3]
     m[3] = m3
     @assert m3 != m3_old # if this is the case we're leaving preformance on the table in a big way
-    if m3_old < m3 # Increase shift, on removal of elements
+    if signed(m3_old) < signed(m3) # Increase shift, on removal of elements TODO for security: add a test that fails when `signed` is removed here.
         # Story:
         # In the likely case that the weight decrease resulted in a level's weight hitting zero
         # that level's weight is already updated and m[4] adjusted accordingly TODO for perf don't adjust, pass the values around instead


### PR DESCRIPTION
This addresses a longstanding `TODO for perf`.

This does come at a significant cost for the pathological2 benchmark; hopefully we can make up that cost on that benchmark by depending on `m[2]`.