### PR TITLE
Reverse memory layout so that higher exponent corresponds to higher index 

### DIFF
--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -76,3 +76,6 @@ jobs:
                 issue-number: ${{ github.event.pull_request.number }}
                 body-path: body.md
                 edit-mode: replace
+
+            - name: Setup tmate session
+              uses: mxschmitt/action-tmate@v3

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -110,7 +110,6 @@ TODO
 ## Updates
 TODO
 
-
 # Memory layout (TODO: add alternative layout for small cases) =#
 
 # <memory_length::Int>

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -275,7 +275,6 @@ function _set_from_zero!(m::Memory, v::Float64, i::Int)
     weight_index = 5 + 0x7fe - exponent
     significand_sum = update_significand_sum(m, weight_index, significand)
 
-    weight_index = 5 + 0x7fe - exponent
     if m[4] == 0 # if we were empty, set global shift (m[3]) so that m[4] will become ~2^40.
         m[3] = -24 - exponent
 

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -493,7 +493,7 @@ function recompute_weights!(m, m3, m4, range)
     m4
 end
 
-get_alloced_indices(exponent::UInt64) = 10491 - exponent >> 3, exponent << 3 & 0x38 #TODO reverse for clarity
+get_alloced_indices(exponent::UInt64) = 10236 + exponent >> 3, exponent << 3 & 0x38
 
 function _set_to_zero!(m::Memory, i::Int)
     # Find the entry's pos in the edit map table

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -194,10 +194,10 @@ Base.setindex!(w::Weights, v, i::Int) = (_setindex!(w.m, Float64(v), i); w)
         while true
             x = rand(rng, UInt64)
             # p_stage = significand_sum << shift & ...00000.111111...64...11110000
-            target = significand_sum << (shift + 64) % UInt64
+            shift += 64
+            target = significand_sum << shift % UInt64
             x > target && @goto reject
             x < target && break
-            shift += 64
             shift >= 0 && break
         end
     end

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -422,10 +422,9 @@ function _set_from_zero!(m::Memory, v::Float64, i::Int)
     nothing
 end
 
-merge_uint64(x::UInt64, y::UInt64) = UInt128(x) | (UInt128(y) << 64)
 split_uint128(x::UInt128) = (x % UInt64, (x >>> 64) % UInt64)
 get_UInt128(m::Memory, i::Integer) = get_UInt128(m, _convert(Int, i))
-get_UInt128(m::Memory, i::Int) = merge_uint64(m[i], m[i+1])
+get_UInt128(m::Memory, i::Int) = UInt128(m[i]) | (UInt128(m[i+1]) << 64)
 
 function set_global_shift_increase!(m::Memory, m2, m3::UInt64, m4) # Increase shift, on deletion of elements
     @assert signed(m[3]) < signed(m3)

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -191,7 +191,7 @@ Base.setindex!(w::Weights, v, i::Int) = (_setindex!(w.m, Float64(v), i); w)
         j = 2i+2041
         exponent = 0x7fe+5-i
         shift = signed(exponent + m[3])
-        significand_sum = merge_uint64(m[j], m[j+1])
+        significand_sum = get_UInt128(m, j)
         while true
             x = rand(rng, UInt64)
             # p_stage = significand_sum << shift & ...00000.111111...64...11110000

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -251,11 +251,11 @@ function _set_nonzero!(m, v, i)
     _set_from_zero!(m, v, i)
 end
 
-function get_significand_sum(m, i)
+@inline function get_significand_sum(m, i)
     i = _convert(Int, 2i+2041)
     significand_sum = UInt128(m[i]) | (UInt128(m[i+1]) << 64)
 end
-function update_significand_sum(m, i, delta)
+@inline function update_significand_sum(m, i, delta)
     j = _convert(Int, 2i+2041)
     significand_sum = get_significand_sum(m, i) + delta
     m[j:j+1] .= (significand_sum % UInt64, (significand_sum >>> 64) % UInt64)

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -542,7 +542,7 @@ function _set_to_zero!(m::Memory, i::Int)
         # TODO refactor indexing for simplicity
         x2 = UInt64(x>>63) #TODO for perf %UInt64
         @assert x2 != 0
-        for i in 1:Sys.WORD_SIZE # TODO for perf, we can get away with shaving 1 to 10 off of this loop.
+        for i in Sys.WORD_SIZE:-1:1 # This loop is backwards so that memory access is forwards. TODO for perf, we can get away with shaving 1 to 10 off of this loop.
             # This can underflow from significand sums into weights, but that underflow is safe because it can only happen if all the latter weights are zero. Be careful about this when re-arranging the memory layout!
             x2 += _convert(UInt, get_significand_sum(m, m2-i) >> (63+i))
         end

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -115,15 +115,15 @@ TODO
 
 # <memory_length::Int>
 # 1                      length::Int
-# 2                      max_level::Int # absolute pointer to the first element of level weights that is nonzero
+# 2                      max_level::Int # absolute pointer to the last element of level weights that is nonzero
 # 3                      shift::Int level weights are equal to significand_sums<<(exponent+shift), plus one if significand_sum is not zero
 # 4                      sum(level weights)::UInt64
-# 5..2050                level weights::[UInt64 2046] # earlier is higher. first is exponent 0x7fe, last is exponent 0x001. Subnormal are not supported.
+# 5..2050                level weights::[UInt64 2046] # earlier is lower. first is exponent 0x001, last is exponent 0x7fe. Subnormal are not supported (TODO).
 # 2051..6142             significand_sums::[UInt128 2046] # sum of significands (the maximum significand contributes 0xfffffffffffff800)
 # 6143..10234            level location info::[NamedTuple{pos::Int, length::Int} 2046] indexes into sub_weights, pos is absolute into m.
 
 # gc info:
-# 10235                  next_free_space::Int (used to re-allocate) <index 10235>
+# 10235                  next_free_space::Int (used to re-allocate)
 # 16 unused bits
 # 10236..10491           level allocated length::[UInt8 2046] (2^(x-1) is implied)
 
@@ -174,7 +174,7 @@ Base.setindex!(w::Weights, v, i::Int) = (_setindex!(w.m, Float64(v), i); w)
         mi = m[i]
         x <= mi && break
         x -= mi
-        i += 1
+        i -= 1
     end
 
     # Low-probability rejection to improve accuracy from very close to perfect
@@ -188,7 +188,7 @@ Base.setindex!(w::Weights, v, i::Int) = (_setindex!(w.m, Float64(v), i); w)
         # rejection_p = 1 - exact(significand_sum)<<shift & ...0000.1111...
         # acceptance_p = exact(significand_sum)<<shift & ...0000.1111...  (for example, if significand_sum<<shift is exact, then acceptance_p will be zero)
         # TODO for confidence: add a test that fails if this were to mix up floor+1 and ceil.
-        exponent = 0x7fe+5-i
+        exponent = i-4
         shift = signed(exponent + m[3])
         significand_sum = get_significand_sum(m, i)
         while true
@@ -272,7 +272,7 @@ function _set_from_zero!(m::Memory, v::Float64, i::Int)
     m[j+1] = exponent
     # update group total weight and total weight
     significand = 0x8000000000000000 | uv << 11
-    weight_index = 5 + 0x7fe - exponent
+    weight_index = exponent + 4
     significand_sum = update_significand_sum(m, weight_index, significand)
 
     if m[4] == 0 # if we were empty, set global shift (m[3]) so that m[4] will become ~2^40.
@@ -308,8 +308,8 @@ function _set_from_zero!(m::Memory, v::Float64, i::Int)
             # If weights overflow (>2^64) then shift down by 16 bits
             m3 = m[3]-0x10
             set_global_shift_decrease!(m, m3, m4) # TODO for perf: special case all call sites to this function to take advantage of known shift direction and/or magnitude; also try outlining
-            if weight_index < m[2] # if the new weight was not adjusted by set_global_shift_decrease!, then adjust it manually
-                shift = signed(2051-weight_index+m3)
+            if weight_index > m[2] # if the new weight was not adjusted by set_global_shift_decrease!, then adjust it manually
+                shift = signed(exponent+m3)
                 new_weight = (significand_sum<<shift) % UInt64 + 1
 
                 @assert significand_sum != 0
@@ -322,10 +322,10 @@ function _set_from_zero!(m::Memory, v::Float64, i::Int)
             m[4] = m4
         end
     end
-    m[2] = min(m[2], weight_index) # Set after insertion because update_weights! may need to update the global shift, in which case knowing the old m[2] will help it skip checking empty levels
+    m[2] = max(m[2], weight_index) # Set after insertion because update_weights! may need to update the global shift, in which case knowing the old m[2] will help it skip checking empty levels
 
     # lookup the group by exponent and bump length
-    group_length_index = 6 + 5*2046 - 2exponent
+    group_length_index = 4 + 3*2046 + 2exponent
     group_pos = m[group_length_index-1]
     group_length = m[group_length_index]+1
     m[group_length_index] = group_length # setting this before compaction means that compaction will ensure there is enough space for this expanded group, but will also copy one index (16 bytes) of junk which could access past the end of m. The junk isn't an issue once coppied because we immediately overwrite it. The former (copying past the end of m) only happens if the group to be expanded is already kissing the end. In this case, it will end up at the end after compaction and be easily expanded afterwords. Consequently, we treat that case specially and bump group length and manually expand after compaction
@@ -438,12 +438,13 @@ function set_global_shift_increase!(m::Memory, m2, m3::UInt64, m4) # Increase sh
     UInt64(significand_sum<<shift) == 0
     and because shift < 0 and significand_sum could be as much as 2^64*2^64/8/8-1 = 2^122-1,
     shift <= -122
-    shift = signed(2051-i+m3)
-    signed(2051-i+m3) <= -122
-    2173+signed(m3) <= i
-    So for i < 2173+signed(m3), we could need to adjust the ith weight
+    shift = signed(exponent+m3)
+    shift = signed(i-4+m3)
+    signed(i-4+m3) <= -122
+    i <= -signed(m3)-122+4
+    So for -signed(m3)-118 < i, we could need to adjust the ith weight
     =#
-    recompute_range = m2:min(2172+signed(m3), 2050) # TODO It would be possible to scale this range with length (m[1]) in which case testing could be stricter and performance could be (marginally) better, though not in large cases so possibly not worth doing at all)
+    recompute_range = max(5, -signed(m3)-117):m2 # TODO It would be possible to scale this range with length (m[1]) in which case testing could be stricter and performance could be (marginally) better, though not in large cases so possibly not worth doing at all)
     m[4] = recompute_weights!(m, m3, m4, recompute_range)
 end
 
@@ -453,19 +454,18 @@ function set_global_shift_decrease!(m::Memory, m3::UInt64, m4=m[4]) # Decrease s
     @assert signed(m3) < signed(m3_old)
 
     # In the case of adding a giant element, call this first, then add the element.
-    # In any case, this only adjusts elements at or after m[2]
-    # from m[2] to the last index that could have a weight > 1 (possibly empty), recompute weights.
-    # from max(m[2], the first index that can't have a weight > 1) to the last index that previously could have had a weight > 1, (never empty), set weights to 1 or 0
+    # In any case, this only adjusts elements at or before m[2]
+    # from the first index that previously could have had a weight > 1 to min(m[2], the first index that can't have a weight > 1) (never empty), set weights to 1 or 0
+    # from the first index that could have a weight > 1 to m[2] (possibly empty), recompute weights.
     m2 = signed(m[2])
-    i1 = 2172+signed(m3) # see above, this is the last index that could have weight > 1 (anything after this will have weight 1 or 0)
-    i1_old = 2172+signed(m3_old) # anything after this is already weight 1 or 0
-    recompute_range = m2:min(i1, 2050)
-    flatten_range = max(m2, i1+1):min(i1_old, 2050)
+    i1 = -signed(m3)-117 # see above, this is the first index that could have weight > 1 (anything after this will have weight 1 or 0)
+    i1_old = -signed(m3_old)-117 # anything before this is already weight 1 or 0
+    flatten_range = max(i1_old, 5):min(m2, i1-1)
+    recompute_range = max(i1, 5):m2
     # From the level where one element contributes 2^64 to the level where one element contributes 1 is 64, and from there to the level where 2^64 elements contributes 1 is another 2^64.
-    @assert length(recompute_range) <= 128
     @assert length(flatten_range) <= 128
+    @assert length(recompute_range) <= 128
 
-    m4 = recompute_weights!(m, m3, m4, recompute_range)
     checkbounds(m, flatten_range)
     @inbounds for i in flatten_range # set nonzeros to 1
         old_weight = m[i]
@@ -473,6 +473,7 @@ function set_global_shift_decrease!(m::Memory, m3::UInt64, m4=m[4]) # Decrease s
         m[i] = weight
         m4 += weight-old_weight
     end
+    m4 = recompute_weights!(m, m3, m4, recompute_range)
 
     m[4] = m4
 end
@@ -482,7 +483,7 @@ function recompute_weights!(m, m3, m4, range)
     @inbounds for i in range
         significand_sum = get_significand_sum(m, i)
         significand_sum == 0 && continue # in this case, the weight was and still is zero
-        shift = signed(2051-i+m3)
+        shift = signed(i-4+m3)
         weight = (significand_sum<<shift) % UInt64 + 1
 
         old_weight = m[i]
@@ -492,7 +493,7 @@ function recompute_weights!(m, m3, m4, range)
     m4
 end
 
-get_alloced_indices(exponent::UInt64) = 10491 - exponent >> 3, exponent << 3 & 0x38
+get_alloced_indices(exponent::UInt64) = 10491 - exponent >> 3, exponent << 3 & 0x38 #TODO reverse for clarity
 
 function _set_to_zero!(m::Memory, i::Int)
     # Find the entry's pos in the edit map table
@@ -505,7 +506,7 @@ function _set_to_zero!(m::Memory, i::Int)
 
     # update group total weight and total weight
     significand = m[pos]
-    weight_index = 5 + 0x7fe - exponent
+    weight_index = exponent + 4
     significand_sum = update_significand_sum(m, weight_index, -UInt128(significand))
     old_weight = m[weight_index]
     m4 = m[4]
@@ -513,13 +514,13 @@ function _set_to_zero!(m::Memory, i::Int)
     if significand_sum == 0 # We zeroed out a group
         m[weight_index] = 0
         if m4 == 0 # There are no groups left
-            m[2] = 2051
+            m[2] = 4
         else
             m2 = Int(m[2])
             if weight_index == m2 # We zeroed out the first group
-                m[10235] != 0 && firstindex(m) <= m2 < 10235 && m2 isa Int || error() # This makes the following @inbounds safe. If the compiler can follow my reasoning, then the error checking can also improve effect analysis and therefore performance.
+                m[4] != 0 && 1 < m2 <= lastindex(m) && m2 isa Int || error() # This makes the following @inbounds safe. If the compiler can follow my reasoning, then the error checking can also improve effect analysis and therefore performance.
                 while true # Update m[2]
-                    m2 += 1
+                    m2 -= 1
                     @inbounds m[m2] != 0 && break # TODO, see if the compiler can infer noub
                 end
                 m[2] = m2
@@ -544,7 +545,8 @@ function _set_to_zero!(m::Memory, i::Int)
         x2 = UInt64(x>>63) #TODO for perf %UInt64
         @assert x2 != 0
         for i in 1:Sys.WORD_SIZE # TODO for perf, we can get away with shaving 1 to 10 off of this loop.
-            x2 += _convert(UInt, get_significand_sum(m, m2+i) >> (63+i))
+            # This can underflow from significand sums into weights, but that underflow is safe because it can only happen if all the latter weights are zero. Be careful about this when re-arranging the memory layout!
+            x2 += _convert(UInt, get_significand_sum(m, m2-i) >> (63+i))
         end
 
         # x2 is computed by rounding down at a certain level and then summing
@@ -558,7 +560,7 @@ function _set_to_zero!(m::Memory, i::Int)
         # squeeze a few more bits out of this, but targeting 46 with a window of 46 to 52 is
         # plenty good enough.
 
-        m3 = -17 - Base.top_set_bit(x2) - 2051 + m2
+        m3 = -17 - Base.top_set_bit(x2) - (m2 - 4)
         # TODO test that this actually achieves the desired shift and results in a new sum of about 2^48
 
         set_global_shift_increase!(m, m2, m3, m4) # TODO for perf: special case all call sites to this function to take advantage of known shift direction and/or magnitude; also try outlining
@@ -569,7 +571,7 @@ function _set_to_zero!(m::Memory, i::Int)
     end
 
     # lookup the group by exponent
-    group_length_index = 6 + 5*2046 - 2exponent
+    group_length_index = 4 + 3*2046 + 2exponent
     group_pos = m[group_length_index-1]
     group_length = m[group_length_index]
     group_lastpos = (group_pos-2)+2group_length
@@ -602,7 +604,7 @@ function FixedSizeWeights(len::Integer)
     # m .= 0 # This is here so that a sparse rendering for debugging is easier TODO for tests: set this to 0xdeadbeefdeadbeed
     m[4:10491+2len] .= 0 # metadata and edit map need to be zeroed but the bulk does not
     m[1] = len
-    m[2] = 2051
+    m[2] = 4
     # no need to set m[3]
     m[10235] = 10492+2len
     _FixedSizeWeights(m)
@@ -685,7 +687,7 @@ function compact!(dst::Memory{UInt64}, src::Memory{UInt64})
         # Lookup the group in the group location table to find its length (performance optimization for copying, necessary to decide new allocated size and update pos)
         # exponent of 0x00000000000007fe is index 6+3*2046
         # exponent of 0x0000000000000001 is index 4+5*2046
-        group_length_index = 6 + 5*2046 - 2exponent
+        group_length_index = 4 + 3*2046 + 2exponent
         group_length = src[group_length_index]
 
         # Update group pos in level_location_info

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -251,11 +251,11 @@ function _set_nonzero!(m, v, i)
     _set_from_zero!(m, v, i)
 end
 
-@inline function get_significand_sum(m, i)
+function get_significand_sum(m, i)
     i = _convert(Int, 2i+2041)
     significand_sum = UInt128(m[i]) | (UInt128(m[i+1]) << 64)
 end
-@inline function update_significand_sum(m, i, delta)
+function update_significand_sum(m, i, delta)
     j = _convert(Int, 2i+2041)
     significand_sum = get_significand_sum(m, i) + delta
     m[j:j+1] .= (significand_sum % UInt64, (significand_sum >>> 64) % UInt64)

--- a/test/invariants.jl
+++ b/test/invariants.jl
@@ -3,7 +3,7 @@ _get_UInt128(m::Memory, i::Integer) = UInt128(m[i]) | (UInt128(m[i+1]) << 64)
 function verify_weights(m::Memory)
     m3 = m[3]
     for i in 5:2050
-        shift = signed(2051 + m3 - i)
+        shift = signed(i - 4 + m3)
         weight = m[i]
         shifted_significand_sum_index = 2041 + 2i
         shifted_significand_sum = _get_UInt128(m, shifted_significand_sum_index)
@@ -14,7 +14,7 @@ function verify_weights(m::Memory)
 end
 
 function verify_m2(m::Memory)
-    @assert m[2] == findfirst(i -> i == 2051 || 5 <= i && m[i] != 0, 1:2051)
+    @assert m[2] == findlast(i -> i == 4 || m[i] != 0, 1:2050)
 end
 function verify_m4(m::Memory)
     m4 = zero(UInt64)

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -210,7 +210,7 @@ verify(w.m)
 w = DynamicDiscreteSamplers.FixedSizeWeights(10)
 w[1] = floatmin(Float64)
 w[2] = floatmax(Float64)
-# w[2] = 0 # This previously threw an assertion error due to overflow when estimating sum of level weights
+w[2] = 0 # This previously threw an assertion error due to overflow when estimating sum of level weights
 verify(w.m)
 
 # These tests have never revealed a bug that was not revealed by one of the above tests:

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -207,6 +207,12 @@ w[23] = 0.9876032886161744
 w[31] = 1.1160998022859043
 verify(w.m)
 
+w = DynamicDiscreteSamplers.FixedSizeWeights(10)
+w[1] = floatmin(Float64)
+w[2] = floatmax(Float64)
+# w[2] = 0 # This previously threw an assertion error due to overflow when estimating sum of level weights
+verify(w.m)
+
 # These tests have never revealed a bug that was not revealed by one of the above tests:
 w = DynamicDiscreteSamplers.FixedSizeWeights(10)
 w[1] = 1


### PR DESCRIPTION
Reverse memory layout so that higher exponent corresponds to higher index and some other minor clarifications.

Fixes:

```julia
w = DynamicDiscreteSamplers.FixedSizeWeights(10)
w[1] = floatmin(Float64)
w[2] = floatmax(Float64)
w[2] = 0 # This previously threw an assertion error due to overflow when estimating sum of level weights
verify(w.m)
```