### PR TITLE
Store a "BitVector" tracking which levels are nonempty to aid updating m2

### DIFF
--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -496,7 +496,7 @@ function recompute_weights!(m, m3, m4, range)
 end
 
 get_alloced_indices(exponent::UInt64) = _convert(Int, 10268 + exponent >> 3), exponent << 3 & 0x38
-get_level_weights_nonzero_indices(exponent::UInt64) = 10235 + exponent >> 6, exponent & 0x3f
+get_level_weights_nonzero_indices(exponent::UInt64) = _convert(Int, 10235 + exponent >> 6), exponent & 0x3f
 
 function _set_to_zero!(m::Memory, i::Int)
     # Find the entry's pos in the edit map table
@@ -521,7 +521,7 @@ function _set_to_zero!(m::Memory, i::Int)
         if m4 == 0 # There are no groups left
             m[2] = 4
         else
-            m2 = _convert(Int, m[2])
+            m2 = m[2]
             if weight_index == m2 # We zeroed out the first group
                 while chunk == 0 # Find the new m[2]
                     level_weights_nonzero_index -= 1

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -128,7 +128,7 @@ TODO
 # 16 unused bits
 # 10268..10523           level allocated length::[UInt8 2046] (2^(x-1) is implied)
 
-# 10524..10523+len       edit_map (maps index to current location in sub_weights)::[(pos<<11 + exponent)::UInt64] (zero means zero; fixed location, always at the start. Force full realloc when it OOMs.
+# 10524..10523+len       edit_map (maps index to current location in sub_weights)::[(pos<<11 + exponent)::UInt64] (zero means zero; fixed location, always at the start. Force full realloc when it OOMs. (len refers to allocated length, not m[1])
 
 # 10524+2len..10523+7len sub_weights (woven with targets)::[[significand::UInt64, target::Int}]]. allocated_len == length_from_memory(length(m)) (len refers to allocated length, not m[1])
 

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -521,21 +521,14 @@ function _set_to_zero!(m::Memory, i::Int)
         if m4 == 0 # There are no groups left
             m[2] = 4
         else
-            m2 = Int(m[2])
+            m2 = m[2]
             if weight_index == m2 # We zeroed out the first group
-                m2′ = m2
-                while chunk == 0
+                while chunk == 0 # Find the new m[2]
                     level_weights_nonzero_index -= 1
-                    m2′ -= 64
+                    m2 -= 64
                     chunk = m[level_weights_nonzero_index]
                 end
-                m2′ += (63-trailing_zeros(chunk)) - level_weights_nonzero_subindex
-                m[4] != 0 && 1 < m2 <= lastindex(m) && m2 isa Int || error() # This makes the following @inbounds safe. If the compiler can follow my reasoning, then the error checking can also improve effect analysis and therefore performance.
-                while true # Update m[2]
-                    m2 -= 1
-                    @inbounds m[m2] != 0 && break # TODO, see if the compiler can infer noub
-                end
-                @assert m2 == m2′
+                m2 += 63-trailing_zeros(chunk) - level_weights_nonzero_subindex
                 m[2] = m2
             end
         end

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -130,7 +130,7 @@ TODO
 
 # 10524..10523+len       edit_map (maps index to current location in sub_weights)::[(pos<<11 + exponent)::UInt64] (zero means zero; fixed location, always at the start. Force full realloc when it OOMs.
 
-# 10524+2len..10523+7len sub_weights (woven with targets)::[[significand::UInt64, target::Int}]]. allocated_len == length_from_memory(length(m))
+# 10524+2len..10523+7len sub_weights (woven with targets)::[[significand::UInt64, target::Int}]]. allocated_len == length_from_memory(length(m)) (len refers to allocated length, not m[1])
 
 # significands are stored in sub_weights with their implicit leading 1 added
 #     element_from_sub_weights = 0x8000000000000000 | (reinterpret(UInt64, weight::Float64) << 11)

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -120,15 +120,17 @@ TODO
 # 5..2050                level weights::[UInt64 2046] # earlier is lower. first is exponent 0x001, last is exponent 0x7fe. Subnormal are not supported (TODO).
 # 2051..6142             significand_sums::[UInt128 2046] # sum of significands (the maximum significand contributes 0xfffffffffffff800)
 # 6143..10234            level location info::[NamedTuple{pos::Int, length::Int} 2046] indexes into sub_weights, pos is absolute into m.
+# 10236..10267           level_weights_nonzero::[Bool 2046] # map of which levels have nonzero weight (used to bump m2 efficiently when a level is zeroed out)
+# 2 unused bits
 
 # gc info:
-# 10235                  next_free_space::Int (used to re-allocate)
+# 10267                  next_free_space::Int (used to re-allocate)
 # 16 unused bits
-# 10236..10491           level allocated length::[UInt8 2046] (2^(x-1) is implied)
+# 10268..10523           level allocated length::[UInt8 2046] (2^(x-1) is implied)
 
-# 10492..10491+len       edit_map (maps index to current location in sub_weights)::[(pos<<11 + exponent)::UInt64] (zero means zero; fixed location, always at the start. Force full realloc when it OOMs.
+# 10524..10523+len       edit_map (maps index to current location in sub_weights)::[(pos<<11 + exponent)::UInt64] (zero means zero; fixed location, always at the start. Force full realloc when it OOMs.
 
-# 10492+2allocated_len..10491+2allocated_len+6len sub_weights (woven with targets)::[[significand::UInt64, target::Int}]]. allocated_len == length_from_memory(length(m))
+# 10524+2allocated_len..10523+2allocated_len+6len sub_weights (woven with targets)::[[significand::UInt64, target::Int}]]. allocated_len == length_from_memory(length(m))
 
 # significands are stored in sub_weights with their implicit leading 1 added
 #     element_from_sub_weights = 0x8000000000000000 | (reinterpret(UInt64, weight::Float64) << 11)
@@ -218,7 +220,7 @@ end
 
 function _getindex(m::Memory{UInt64}, i::Int)
     @boundscheck 1 <= i <= m[1] || throw(BoundsError(_FixedSizeWeights(m), i))
-    j = i + 10491
+    j = i + 10523
     exponent = m[j] & 2047
     pos = m[j] >> 11
     pos == 0 && return 0.0
@@ -236,7 +238,7 @@ function _setindex!(m::Memory, v::Float64, i::Int)
     0x0010000000000000 <= uv <= 0x7fefffffffffffff || throw(DomainError(v, "Invalid weight")) # Excludes subnormals
 
     # Find the entry's pos in the edit map table
-    j = i + 10491
+    j = i + 10523
     pos = m[j] >> 11
     if pos == 0
         _set_from_zero!(m, v, i)
@@ -264,7 +266,7 @@ end
 
 function _set_from_zero!(m::Memory, v::Float64, i::Int)
     uv = reinterpret(UInt64, v)
-    j = i + 10491
+    j = i + 10523
     @assert m[j] == 0
 
     exponent = uv >> 52
@@ -334,7 +336,7 @@ function _set_from_zero!(m::Memory, v::Float64, i::Int)
 
     # if there is not room in the group, shift and expand
     if group_length > allocated_size
-        next_free_space = m[10235]
+        next_free_space = m[10267]
         # if at end already, simply extend the allocation # TODO see if removing this optimization is problematic; TODO verify the optimization is triggering
         if next_free_space == (group_pos-2)+2group_length # note that this is valid even if group_length is 1 (previously zero).
             new_allocation_length = max(2, 2allocated_size)
@@ -357,7 +359,7 @@ function _set_from_zero!(m::Memory, v::Float64, i::Int)
             # expand the allocated size and bump next_free_space
             new_chunk = allocs_chunk + UInt64(1) << allocs_subindex
             m[allocs_index] = new_chunk
-            m[10235] = new_next_free_space
+            m[10267] = new_next_free_space
         else # move and reallocate (this branch also handles creating new groups: TODO expirment with perf and clarity by splicing that branch out)
             twice_new_allocated_size = max(0x2,allocated_size<<2)
             new_next_free_space = next_free_space+twice_new_allocated_size
@@ -385,7 +387,7 @@ function _set_from_zero!(m::Memory, v::Float64, i::Int)
             new_chunk = allocs_chunk + UInt64(1) << allocs_subindex
             m[allocs_index] = new_chunk
 
-            m[10235] = new_next_free_space
+            m[10267] = new_next_free_space
 
             # Copy the group to new location
             (v"1.11" <= VERSION || 2group_length-2 != 0) && unsafe_copyto!(m, next_free_space, m, group_pos, 2group_length-2) # TODO for clarity and maybe perf: remove this version check
@@ -394,7 +396,7 @@ function _set_from_zero!(m::Memory, v::Float64, i::Int)
             delta = (next_free_space-group_pos) << 11
             for k in 1:group_length-1
                 target = m[next_free_space+2k-1]
-                l = target + 10491
+                l = target + 10523
                 m[l] += delta
             end
 
@@ -491,11 +493,11 @@ function recompute_weights!(m, m3, m4, range)
     m4
 end
 
-get_alloced_indices(exponent::UInt64) = 10236 + exponent >> 3, exponent << 3 & 0x38
+get_alloced_indices(exponent::UInt64) = 10268 + exponent >> 3, exponent << 3 & 0x38
 
 function _set_to_zero!(m::Memory, i::Int)
     # Find the entry's pos in the edit map table
-    j = i + 10491
+    j = i + 10523
     pos = m[j] >> 11
     pos == 0 && return # if the entry is already zero, return
     exponent = m[j] & 2047
@@ -580,7 +582,7 @@ function _set_to_zero!(m::Memory, i::Int)
     shifted_element = m[pos+1] = m[group_lastpos+1]
 
     # adjust the edit map entry of the shifted element
-    m[shifted_element + 10491] = pos << 11 + exponent
+    m[shifted_element + 10523] = pos << 11 + exponent
     m[j] = 0
 
     # When zeroing out a group, mark the group as empty so that compaction will update the group metadata and then skip over it.
@@ -600,15 +602,15 @@ SemiResizableWeights(len::Integer) = SemiResizableWeights(FixedSizeWeights(len))
 function FixedSizeWeights(len::Integer)
     m = Memory{UInt64}(undef, allocated_memory(len))
     # m .= 0 # This is here so that a sparse rendering for debugging is easier TODO for tests: set this to 0xdeadbeefdeadbeed
-    m[4:10491+len] .= 0 # metadata and edit map need to be zeroed but the bulk does not
+    m[4:10523+len] .= 0 # metadata and edit map need to be zeroed but the bulk does not
     m[1] = len
     m[2] = 4
     # no need to set m[3]
-    m[10235] = 10492+len
+    m[10267] = 10524+len
     _FixedSizeWeights(m)
 end
-allocated_memory(length::Integer) = 10491 + 7*length # TODO for perf: consider giving some extra constant factor allocation to avoid repeated compaction at small sizes
-length_from_memory(allocated_memory::Integer) = Int((allocated_memory-10491)/7)
+allocated_memory(length::Integer) = 10523 + 7*length # TODO for perf: consider giving some extra constant factor allocation to avoid repeated compaction at small sizes
+length_from_memory(allocated_memory::Integer) = Int((allocated_memory-10523)/7)
 
 Base.resize!(w::Union{SemiResizableWeights, ResizableWeights}, len::Integer) = resize!(w, Int(len))
 function Base.resize!(w::Union{SemiResizableWeights, ResizableWeights}, len::Int)
@@ -640,10 +642,10 @@ function _resize!(w::ResizableWeights, len::Integer)
     # m2 .= 0 # For debugging; TODO: set to 0xdeadbeefdeadbeef to test
     m2[1] = len
     if len > old_len # grow
-        unsafe_copyto!(m2, 2, m, 2, old_len + 10491)
-        m2[old_len + 10492:len + 10491] .= 0
+        unsafe_copyto!(m2, 2, m, 2, old_len + 10523)
+        m2[old_len + 10524:len + 10523] .= 0
     else # shrink
-        unsafe_copyto!(m2, 2, m, 2, len + 10491)
+        unsafe_copyto!(m2, 2, m, 2, len + 10523)
     end
 
     compact!(m2, m)
@@ -652,9 +654,9 @@ function _resize!(w::ResizableWeights, len::Integer)
 end
 
 function compact!(dst::Memory{UInt64}, src::Memory{UInt64})
-    dst_i = Int(length_from_memory(length(dst)) + 10492)
-    src_i = Int(length_from_memory(length(src)) + 10492)
-    next_free_space = src[10235]
+    dst_i = Int(length_from_memory(length(dst)) + 10524)
+    src_i = Int(length_from_memory(length(src)) + 10524)
+    next_free_space = src[10267]
 
     while src_i < next_free_space
 
@@ -679,7 +681,7 @@ function compact!(dst::Memory{UInt64}, src::Memory{UInt64})
         end
 
         # Trace an element of the group back to the edit info table to find the group id
-        j = target + 10491
+        j = target + 10523
         exponent = src[j] & 2047
 
         # Lookup the group in the group location table to find its length (performance optimization for copying, necessary to decide new allocated size and update pos)
@@ -713,7 +715,7 @@ function compact!(dst::Memory{UInt64}, src::Memory{UInt64})
         dst[j] += delta
         for k in 1:signed(group_length)-1 # TODO: add a benchmark that stresses compaction and try hoisting this bounds checking
             target = src[src_i+2k+1]
-            j = target + 10491
+            j = target + 10523
             dst[j] += delta
         end
 
@@ -722,7 +724,7 @@ function compact!(dst::Memory{UInt64}, src::Memory{UInt64})
         dst_i += 2*1<<log2_new_allocated_size
     end
     @label break_outer
-    dst[10235] = dst_i
+    dst[10267] = dst_i
 end
 
 # Conform to the AbstractArray API

--- a/test/invariants.jl
+++ b/test/invariants.jl
@@ -1,6 +1,6 @@
 isdefined(@__MODULE__, :Memory) || const Memory = Vector # Compat for Julia < 1.11
 _get_UInt128(m::Memory, i::Integer) = UInt128(m[i]) | (UInt128(m[i+1]) << 64)
-_length_from_memory(allocated_memory::Integer) = Int((allocated_memory-10491)/7)
+_length_from_memory(allocated_memory::Integer) = Int((allocated_memory-10523)/7)
 function verify_weights(m::Memory)
     m3 = m[3]
     for i in 5:2050

--- a/test/invariants.jl
+++ b/test/invariants.jl
@@ -30,7 +30,7 @@ function verify_edit_map_points_to_correct_target(m::Memory)
     filled_len = m[1]
     len = _length_from_memory(length(m))
     for i in 1:len
-        edit_map_entry = m[i+10491]
+        edit_map_entry = m[i+10523]
         if i > filled_len
             @assert edit_map_entry == 0
         elseif edit_map_entry != 0


### PR DESCRIPTION
Targets pathological2 and pathological4, our worst cases.