### PR TITLE
Fix indexing bug in pathological5b

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -139,8 +139,8 @@ function pathological5b_setup()
     ds
 end
 function pathological5b_update(ds)
-    push!(ds, 33, 2.0^30)
-    delete!(ds, 33)
+    push!(ds, 129, 2.0^30)
+    delete!(ds, 129)
 end
 SUITE["pathological 5b"] = @benchmarkable pathological5b_setup pathological5b_update
 


### PR DESCRIPTION
This fixes https://github.com/LilithHafner/DynamicDiscreteSamplers.jl/commit/d1e43ab19328f50c90babce4f65ea3e196940946#r152520907 and makes the benchmark run on main.