### PR TITLE
Factor out slow path in `_rand` and defer recomputing weights upward to that path.

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -162,7 +162,7 @@ function pathological5b_update(ds)
 end
 SUITE["pathological 5b"] = @benchmarkable pathological5b_setup pathological5b_update
 function pathological5b′_update(ds)
-    push!(ds, 129, 2.0^30)
+    push!(ds, 129, 2.0^48)
     delete!(ds, 129)
     rand(ds)
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -90,6 +90,12 @@ function pathological1_update(ds)
     delete!(ds, 2)
 end
 SUITE["pathological 1"] = @benchmarkable pathological1_setup pathological1_update
+function pathological1′_update(ds)
+    push!(ds, 2, 1e100)
+    delete!(ds, 2)
+    rand(ds)
+end
+SUITE["pathological 1′"] = @benchmarkable pathological1_setup pathological1′_update
 
 function pathological2_setup()
     ds = DynamicDiscreteSampler()
@@ -101,6 +107,12 @@ function pathological2_update(ds)
     delete!(ds, 2)
 end
 SUITE["pathological 2"] = @benchmarkable pathological2_setup pathological2_update
+function pathological2′_update(ds)
+    push!(ds, 2, 1e300)
+    delete!(ds, 2)
+    rand(ds)
+end
+SUITE["pathological 2′"] = @benchmarkable pathological2_setup pathological2′_update
 
 pathological3 = DynamicDiscreteSampler()
 push!(pathological3, 1, 1e300)
@@ -118,6 +130,12 @@ function pathological4_update(ds)
     delete!(ds, 2)
 end
 SUITE["pathological 4"] = @benchmarkable pathological4_setup pathological4_update
+function pathological4′_update(ds)
+    push!(ds, 2, 1e307)
+    delete!(ds, 2)
+    rand(ds)
+end
+SUITE["pathological 4′"] = @benchmarkable pathological4_setup pathological4′_update
 
 
 function pathological5a_setup()
@@ -143,6 +161,12 @@ function pathological5b_update(ds)
     delete!(ds, 129)
 end
 SUITE["pathological 5b"] = @benchmarkable pathological5b_setup pathological5b_update
+function pathological5b′_update(ds)
+    push!(ds, 129, 2.0^30)
+    delete!(ds, 129)
+    rand(ds)
+end
+SUITE["pathological 5b′"] = @benchmarkable pathological5b_setup pathological5b′_update
 
 include("code_size.jl")
 _code_size = code_size(dirname(pathof(DynamicDiscreteSamplers)))

--- a/test/invariants.jl
+++ b/test/invariants.jl
@@ -23,7 +23,7 @@ function verify_m4(m::Memory)
         m4 = Base.checked_add(m4, m[i])
     end
     @assert m[4] == m4
-    @assert m4 == 0 || UInt64(2)^32 <= m4
+    # @assert m4 == 0 || UInt64(2)^32 <= m4
 end
 
 function verify_edit_map_points_to_correct_target(m::Memory)

--- a/test/invariants.jl
+++ b/test/invariants.jl
@@ -23,7 +23,7 @@ function verify_m4(m::Memory)
         m4 = Base.checked_add(m4, m[i])
     end
     @assert m[4] == m4
-    # @assert m4 == 0 || UInt64(2)^32 <= m4
+    # @assert m4 == 0 || UInt64(2)^32 <= m4 # This invariant is now maintained loosely and lazily
 end
 
 function verify_edit_map_points_to_correct_target(m::Memory)


### PR DESCRIPTION
The point of adjusting `m[3]` and recomputing approximate weights to increase `m[4]` above 2^32 is to make sure we hit the slow path infrequently so we only need to do it if we are actually hitting the slow path. This means that pathological cases of repeatedly inserting and removing a weight to stress m[4] require calls to rand in order to trigger approximate level weight recomputation and remain pathological.

This fixes all the pathological cases we currently benchmark to within a factor of 2-3 of main! But... it does not fix some slightly harder to produce pathological cases. But those cases are slightly less pathological, and this PR includes benchmarks for them, and this PR doesn't significantly regress those cases either.

