### PR TITLE
Optimize `recompute_weights!` by splitting the loop

### DIFF
--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -525,10 +525,42 @@ function set_global_shift_decrease!(m::Memory, m3::UInt64, m4=m[4]) # Decrease s
     m[4] = m4
 end
 
-function recompute_weights!(m, m3, m4, range::UnitRange{Int64})
-    checkbounds(m, first(range):2last(range)+2042)
-    @inbounds for i in range
+function recompute_weights!(m::Memory{UInt64}, m3::UInt64, m4::UInt64, range::UnitRange{Int64})
+    isempty(range) && return m4
+    r0,r1 = extrema(range)
+    # shift = signed(i-4+m3)
+    # weight = significand_sum == 0 ? 0 : UInt64(significand_sum << shift) + 1
+    # shift < -64; the low 64 bits are shifted off.
+    # 0 < shift; the high bits stay off
+    # i < -60-signed(m3); the low 64 bits are shifted off.
+    # 4-signed(m3) < i; the high bits stay off
+
+    checkbounds(m, r0:2r1+2042)
+    @inbounds for i in r0:min(r1, -61-signed(m3))
+        significand_sum_lo = m[_convert(Int, 2i+2041)]
+        significand_sum_hi = m[_convert(Int, 2i+2042)]
+        significand_sum_lo == significand_sum_hi == 0 && continue # in this case, the weight was and still is zero
+        shift = signed(i-4+m3) + 64
+        weight = _convert(UInt64, (significand_sum_hi << shift)) + 1
+
+        old_weight = m[i]
+        m[i] = weight
+        m4 += weight-old_weight
+    end
+    @inbounds for i in max(r0,-60-signed(m3)):min(r1, 4-signed(m3))
+    # @inbounds for i in range
         significand_sum = get_significand_sum(m, i)
+        significand_sum == 0 && continue # in this case, the weight was and still is zero
+        shift = signed(i-4+m3)
+        weight = _convert(UInt64, (significand_sum << shift)) + 1
+
+        old_weight = m[i]
+        m[i] = weight
+        m4 += weight-old_weight
+    end
+    @inbounds for i in max(r0, 5-signed(m3)):r1
+        significand_sum = m[_convert(Int, 2i+2041)]
+        @assert m[_convert(Int, 2i+2042)] == 0
         significand_sum == 0 && continue # in this case, the weight was and still is zero
         shift = signed(i-4+m3)
         weight = _convert(UInt64, (significand_sum << shift)) + 1

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -531,9 +531,7 @@ function recompute_weights!(m::Memory{UInt64}, m3::UInt64, m4::UInt64, range::Un
     # shift = signed(i-4+m3)
     # weight = significand_sum == 0 ? 0 : UInt64(significand_sum << shift) + 1
     # shift < -64; the low 64 bits are shifted off.
-    # 0 < shift; the high bits stay off
     # i < -60-signed(m3); the low 64 bits are shifted off.
-    # 4-signed(m3) < i; the high bits stay off
 
     checkbounds(m, r0:2r1+2042)
     @inbounds for i in r0:min(r1, -61-signed(m3))
@@ -543,15 +541,8 @@ function recompute_weights!(m::Memory{UInt64}, m3::UInt64, m4::UInt64, range::Un
         shift = signed(i-4+m3) + 64
         m4 += update_weight!(m, i, significand_sum_hi << shift)
     end
-    @inbounds for i in max(r0,-60-signed(m3)):min(r1, 4-signed(m3))
+    @inbounds for i in max(r0,-60-signed(m3)):r1
         significand_sum = get_significand_sum(m, i)
-        significand_sum == 0 && continue # in this case, the weight was and still is zero
-        shift = signed(i-4+m3)
-        m4 += update_weight!(m, i, significand_sum << shift)
-    end
-    @inbounds for i in max(r0, 5-signed(m3)):r1
-        significand_sum = m[_convert(Int, 2i+2041)]
-        # @assert m[_convert(Int, 2i+2042)] == 0
         significand_sum == 0 && continue # in this case, the weight was and still is zero
         shift = signed(i-4+m3)
         m4 += update_weight!(m, i, significand_sum << shift)

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -541,35 +541,28 @@ function recompute_weights!(m::Memory{UInt64}, m3::UInt64, m4::UInt64, range::Un
         significand_sum_hi = m[_convert(Int, 2i+2042)]
         significand_sum_lo == significand_sum_hi == 0 && continue # in this case, the weight was and still is zero
         shift = signed(i-4+m3) + 64
-        weight = _convert(UInt64, (significand_sum_hi << shift)) + 1
-
-        old_weight = m[i]
-        m[i] = weight
-        m4 += weight-old_weight
+        m4 += update_weight!(m, i, significand_sum_hi << shift)
     end
     @inbounds for i in max(r0,-60-signed(m3)):min(r1, 4-signed(m3))
-    # @inbounds for i in range
         significand_sum = get_significand_sum(m, i)
         significand_sum == 0 && continue # in this case, the weight was and still is zero
         shift = signed(i-4+m3)
-        weight = _convert(UInt64, (significand_sum << shift)) + 1
-
-        old_weight = m[i]
-        m[i] = weight
-        m4 += weight-old_weight
+        m4 += update_weight!(m, i, significand_sum << shift)
     end
     @inbounds for i in max(r0, 5-signed(m3)):r1
         significand_sum = m[_convert(Int, 2i+2041)]
-        @assert m[_convert(Int, 2i+2042)] == 0
+        # @assert m[_convert(Int, 2i+2042)] == 0
         significand_sum == 0 && continue # in this case, the weight was and still is zero
         shift = signed(i-4+m3)
-        weight = _convert(UInt64, (significand_sum << shift)) + 1
-
-        old_weight = m[i]
-        m[i] = weight
-        m4 += weight-old_weight
+        m4 += update_weight!(m, i, significand_sum << shift)
     end
     m4
+end
+Base.@propagate_inbounds function update_weight!(m::Memory{UInt64}, i, shifted_significand_sum)
+    weight = _convert(UInt64, shifted_significand_sum) + 1
+    old_weight = m[i]
+    m[i] = weight
+    weight-old_weight
 end
 
 get_alloced_indices(exponent::UInt64) = _convert(Int, 10268 + exponent >> 3), exponent << 3 & 0x38

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -248,6 +248,7 @@ w .= repeat(ldexp.(1.0, -1022:1023), inner=2048)
 w[(2046-16)*2048+1:2046*2048] .= 0
 @test w.m[4] < 2.0^32*1.1 # Confirm that we created an interesting condition
 f(w,n) = sum(Int64(rand(w)) for _ in 1:n)
+verify(w.m)
 @test f(w, 2^27) ≈ 4.1543685e6*2^27 rtol=1e-6 # This should fail less than 1e-40 of the time
 
 # These tests have never revealed a bug that was not revealed by one of the above tests:

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -235,6 +235,11 @@ v[3] = w[3] = 0.92
 verify(w.m)
 @test v == w
 
+w = DynamicDiscreteSamplers.ResizableWeights(2)
+w[1] = 0.95
+w[2] = 6.41e14
+verify(w.m)
+
 # This test catches a bug that was not revealed by the RNG tests below.
 # The final line is calibrated to have about a 50% fail rate on that bug
 # and run in about 3 seconds:


### PR DESCRIPTION
Optimize `recompute_weights!` by splitting the loop into two parts based on weather or not the less significant word of significand_sum is used.