### PR TITLE
Update set_global_shift_decrease! to shift weights rather than recomputing them

### DIFF
--- a/.github/workflows/benchmark_pr_3.yml
+++ b/.github/workflows/benchmark_pr_3.yml
@@ -61,6 +61,9 @@ jobs:
                 echo 'A plot of the benchmark results have been uploaded as an artifact to the workflow run for this PR.' >> body.md
                 echo 'Go to "Actions"->"Benchmark a pull request"->[the most recent run]->"Artifacts" (at the bottom).' >> body.md
 
+            - name: ssh
+              uses: mxschmitt/action-tmate@v3
+
             - name: wait
               run: sleep 90
 

--- a/.github/workflows/benchmark_pr_3.yml
+++ b/.github/workflows/benchmark_pr_3.yml
@@ -61,9 +61,6 @@ jobs:
                 echo 'A plot of the benchmark results have been uploaded as an artifact to the workflow run for this PR.' >> body.md
                 echo 'Go to "Actions"->"Benchmark a pull request"->[the most recent run]->"Artifacts" (at the bottom).' >> body.md
 
-            # - name: ssh
-              # uses: mxschmitt/action-tmate@v3
-
             - name: wait
               run: sleep 90
 

--- a/.github/workflows/benchmark_pr_3.yml
+++ b/.github/workflows/benchmark_pr_3.yml
@@ -61,8 +61,8 @@ jobs:
                 echo 'A plot of the benchmark results have been uploaded as an artifact to the workflow run for this PR.' >> body.md
                 echo 'Go to "Actions"->"Benchmark a pull request"->[the most recent run]->"Artifacts" (at the bottom).' >> body.md
 
-            - name: ssh
-              uses: mxschmitt/action-tmate@v3
+            # - name: ssh
+              # uses: mxschmitt/action-tmate@v3
 
             - name: wait
               run: sleep 90

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -494,7 +494,7 @@ function set_global_shift_increase!(m::Memory, m2, m3::UInt64, m4) # Increase sh
     So for -signed(m3)-118 < i, we could need to adjust the ith weight
     =#
     recompute_range = max(5, -signed(m3)-117):m2 # TODO It would be possible to scale this range with length (m[1]) in which case testing could be stricter and performance could be (marginally) better, though not in large cases so possibly not worth doing at all)
-    m[4] = recompute_weights!(m, m3, m4, recompute_range)
+    m[4] = recompute_weights_decrease!(m, m3, m4, recompute_range)
 end
 
 function set_global_shift_decrease!(m::Memory, m3::UInt64, m4=m[4]) # Decrease shift, on insertion of elements

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -528,7 +528,7 @@ function set_global_shift_decrease!(m::Memory, m3::UInt64, m4=m[4]) # Decrease s
     @inbounds for i in recompute_range
         old_weight = m[i]
         old_weight == 0 && continue # in this case, the weight was and still is zero TODO: 1
-        m4 += update_weight!(m, i, old_weight >> delta)
+        m4 += update_weight!(m, i, (old_weight-1) >> delta)
     end
 
     m[4] = m4

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -522,21 +522,32 @@ function set_global_shift_decrease!(m::Memory, m3::UInt64, m4=m[4]) # Decrease s
         m[i] = weight
         m4 += weight-old_weight
     end
-    m4 = recompute_weights_decrease!(m, m3_old, m3, m4, recompute_range)
+    m4 = recompute_weights_decrease!(m, m3, m4, recompute_range)
 
     m[4] = m4
 end
 
-function recompute_weights_decrease!(m::Memory{UInt64}, m3_old::UInt64, m3::UInt64, m4::UInt64, range::UnitRange{Int64})
+function recompute_weights_decrease!(m::Memory{UInt64}, m3::UInt64, m4::UInt64, range::UnitRange{Int64})
     isempty(range) && return m4
-    extrema(range) # why is this here?
+    r0,r1 = extrema(range)
+    # shift = signed(i-4+m3)
+    # weight = significand_sum == 0 ? 0 : UInt64(significand_sum << shift) + 1
+    # shift < -64; the low 64 bits are shifted off.
+    # i < -60-signed(m3); the low 64 bits are shifted off.
 
-    delta = m3_old-m3
-    checkbounds(m, range)
-    @inbounds for i in range
-        old_weight = m[i]
-        old_weight <= 1 && continue # in this case, the weight was and still is 0 or 1
-        m4 += update_weight!(m, i, (old_weight-1) >> delta)
+    checkbounds(m, r0:2r1+2042)
+    @inbounds for i in r0:min(r1, -61-signed(m3))
+        significand_sum_lo = m[_convert(Int, 2i+2041)]
+        significand_sum_hi = m[_convert(Int, 2i+2042)]
+        significand_sum_lo == significand_sum_hi == 0 && continue # in this case, the weight was and still is zero
+        shift = signed(i-4+m3) + 64
+        m4 += update_weight!(m, i, significand_sum_hi << shift)
+    end
+    @inbounds for i in max(r0,-60-signed(m3)):r1
+        significand_sum = get_significand_sum(m, i)
+        significand_sum == 0 && continue # in this case, the weight was and still is zero
+        shift = signed(i-4+m3)
+        m4 += update_weight!(m, i, significand_sum << shift)
     end
     m4
 end

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -318,7 +318,7 @@ function _set_from_zero!(m::Memory, v::Float64, i::Int)
     # update group total weight and total weight
     significand = 0x8000000000000000 | uv << 11
     weight_index = _convert(Int, exponent + 4)
-    significand_sum = update_significand_sum(m, weight_index, significand)
+    significand_sum = update_significand_sum(m, weight_index, significand) # Temporarily break the "weights are accurately computed" invariant
 
     if m[4] == 0 # if we were empty, set global shift (m[3]) so that m[4] will become ~2^40.
         m[3] = -24 - exponent
@@ -339,23 +339,25 @@ function _set_from_zero!(m::Memory, v::Float64, i::Int)
             # Base.top_set_bit(significand_sum)+signed(exponent) + signed(m[3]) == 48
             # signed(m[3]) == 48 - Base.top_set_bit(significand_sum) - signed(exponent)
             m3 = 48 - Base.top_set_bit(significand_sum) - exponent
+            # The "weights are accurately computed" invariant is broken for weight_index, but the "sum(weights) == m[4]" invariant still holds
+            # set_global_shift_decrease! will do something wrong to weight_index, but preserve the "sum(weights) == m[4]" invariant.
             set_global_shift_decrease!(m, m3) # TODO for perf: special case all call sites to this function to take advantage of known shift direction and/or magnitude; also try outlining
             shift = signed(exponent + m3)
         end
         weight = _convert(UInt64, significand_sum << shift) + 1
 
         old_weight = m[weight_index]
-        m[weight_index] = weight
-        m4 = m[4]
+        m[weight_index] = weight # The "weights are accurately computed" invariant is now restored
+        m4 = m[4] # The "sum(weights) == m[4]" invariant is broken
         m4 -= old_weight
-        m4, o = Base.add_with_overflow(m4, weight)
+        m4, o = Base.add_with_overflow(m4, weight) # The "sum(weights) == m4" invariant now holds, though the computation overflows
         if o
             # If weights overflow (>2^64) then shift down by 16 bits
             m3 = m[3]-0x10
             set_global_shift_decrease!(m, m3, m4) # TODO for perf: special case all call sites to this function to take advantage of known shift direction and/or magnitude; also try outlining
             if weight_index > m[2] # if the new weight was not adjusted by set_global_shift_decrease!, then adjust it manually
                 shift = signed(exponent+m3)
-                new_weight = _convert(UInt64, significand_sum << shift) + 1
+                new_weight = _convert(UInt64, significand_sum << shift) + 1 # TODO: refactor to match set_global_shift_decrease!'s implementation
 
                 @assert significand_sum != 0
                 @assert m[weight_index] == weight
@@ -503,7 +505,7 @@ function set_global_shift_decrease!(m::Memory, m3::UInt64, m4=m[4]) # Decrease s
     # In the case of adding a giant element, call this first, then add the element.
     # In any case, this only adjusts elements at or before m[2]
     # from the first index that previously could have had a weight > 1 to min(m[2], the first index that can't have a weight > 1) (never empty), set weights to 1 or 0
-    # from the first index that could have a weight > 1 to m[2] (possibly empty), recompute weights.
+    # from the first index that could have a weight > 1 to m[2] (possibly empty), shift weights by delta.
     m2 = signed(m[2])
     i1 = -signed(m3)-117 # see above, this is the first index that could have weight > 1 (anything after this will have weight 1 or 0)
     i1_old = -signed(m3_old)-117 # anything before this is already weight 1 or 0
@@ -520,7 +522,14 @@ function set_global_shift_decrease!(m::Memory, m3::UInt64, m4=m[4]) # Decrease s
         m[i] = weight
         m4 += weight-old_weight
     end
-    m4 = recompute_weights!(m, m3, m4, recompute_range)
+
+    delta = m3_old-m3
+    checkbounds(m, recompute_range)
+    @inbounds for i in recompute_range
+        old_weight = m[i]
+        old_weight == 0 && continue # in this case, the weight was and still is zero TODO: 1
+        m4 += update_weight!(m, i, old_weight >> delta)
+    end
 
     m[4] = m4
 end

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -357,7 +357,7 @@ function _set_from_zero!(m::Memory, v::Float64, i::Int)
             set_global_shift_decrease!(m, m3, m4) # TODO for perf: special case all call sites to this function to take advantage of known shift direction and/or magnitude; also try outlining
             if weight_index > m[2] # if the new weight was not adjusted by set_global_shift_decrease!, then adjust it manually
                 shift = signed(exponent+m3)
-                new_weight = _convert(UInt64, significand_sum << shift) + 1 # TODO: refactor to match set_global_shift_decrease!'s implementation
+                new_weight = _convert(UInt64, significand_sum << shift) + 1
 
                 @assert significand_sum != 0
                 @assert m[weight_index] == weight

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -527,7 +527,7 @@ function set_global_shift_decrease!(m::Memory, m3::UInt64, m4=m[4]) # Decrease s
     checkbounds(m, recompute_range)
     @inbounds for i in recompute_range
         old_weight = m[i]
-        old_weight == 0 && continue # in this case, the weight was and still is zero TODO: 1
+        old_weight <= 1 && continue # in this case, the weight was and still is 0 or 1
         m4 += update_weight!(m, i, (old_weight-1) >> delta)
     end
 

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -522,16 +522,23 @@ function set_global_shift_decrease!(m::Memory, m3::UInt64, m4=m[4]) # Decrease s
         m[i] = weight
         m4 += weight-old_weight
     end
+    m4 = recompute_weights_decrease!(m, m3_old, m3, m4, recompute_range)
+
+    m[4] = m4
+end
+
+function recompute_weights_decrease!(m::Memory{UInt64}, m3_old::UInt64, m3::UInt64, m4::UInt64, range::UnitRange{Int64})
+    isempty(range) && return m4
+    extrema(range) # why is this here?
 
     delta = m3_old-m3
-    checkbounds(m, recompute_range)
-    @inbounds for i in recompute_range
+    checkbounds(m, range)
+    @inbounds for i in range
         old_weight = m[i]
         old_weight <= 1 && continue # in this case, the weight was and still is 0 or 1
         m4 += update_weight!(m, i, (old_weight-1) >> delta)
     end
-
-    m[4] = m4
+    m4
 end
 
 function recompute_weights!(m::Memory{UInt64}, m3::UInt64, m4::UInt64, range::UnitRange{Int64})

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -240,6 +240,13 @@ w[1] = 0.95
 w[2] = 6.41e14
 verify(w.m)
 
+# This test catches a bug that was not revealed by the RNG tests below
+w = DynamicDiscreteSamplers.FixedSizeWeights(3);
+w[1] = 1.5
+w[2] = prevfloat(1.5)
+w[3] = 2^25
+# verify(w.m)
+
 # This test catches a bug that was not revealed by the RNG tests below.
 # The final line is calibrated to have about a 50% fail rate on that bug
 # and run in about 3 seconds:

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -245,7 +245,7 @@ w = DynamicDiscreteSamplers.FixedSizeWeights(3);
 w[1] = 1.5
 w[2] = prevfloat(1.5)
 w[3] = 2^25
-# verify(w.m)
+verify(w.m)
 
 # This test catches a bug that was not revealed by the RNG tests below.
 # The final line is calibrated to have about a 50% fail rate on that bug


### PR DESCRIPTION
Update set_global_shift_decrease! to shift weights rather than recomputing them, taking advantage of the fact that the shift is always down. Also:

- Add comments about invariants
- Add a test that failed in a WIP version of this PR that is not caught by the rng tests!

Targeted at increasing performance of path 5b′