### PR TITLE
Divide new/old instead of old/new when displaying benchmarks

### DIFF
--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -38,11 +38,11 @@ jobs:
             - name: Run benchmarks
               run: |
                 mkdir results
-                benchpkg --add https://github.com/LilithHafner/ChairmarksForAirspeedVelocity.jl ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.pull_request.base.sha}},${{github.event.pull_request.head.sha}}" --url=${{ github.event.repository.clone_url }} --bench-on="${{github.event.pull_request.head.sha}}" --output-dir=results/ --tune
+                benchpkg --add https://github.com/LilithHafner/ChairmarksForAirspeedVelocity.jl ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.pull_request.head.sha}},${{github.event.pull_request.base.sha}}" --url=${{ github.event.repository.clone_url }} --bench-on="${{github.event.pull_request.head.sha}}" --output-dir=results/ --tune
             - name: Create plots from benchmarks
               run: |
                 mkdir -p plots
-                benchpkgplot ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.pull_request.base.sha}},${{github.event.pull_request.head.sha}}" --npart=10 --format=png --input-dir=results/ --output-dir=plots/
+                benchpkgplot ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.pull_request.head.sha}},${{github.event.pull_request.base.sha}}" --npart=10 --format=png --input-dir=results/ --output-dir=plots/
             - name: Upload plot as artifact
               uses: actions/upload-artifact@v4
               with:
@@ -50,7 +50,7 @@ jobs:
                 path: plots
             - name: Create markdown table from benchmarks
               run: |
-                benchpkgtable ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.pull_request.base.sha}},${{github.event.pull_request.head.sha}}" --input-dir=results/ --ratio > table.md
+                benchpkgtable ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.pull_request.head.sha}},${{github.event.pull_request.base.sha}}" --input-dir=results/ --ratio > table.md
                 echo '### Benchmark Results' > body.md
                 echo '' >> body.md
                 echo '' >> body.md

--- a/.github/workflows/benchmark_pr_2.yml
+++ b/.github/workflows/benchmark_pr_2.yml
@@ -38,11 +38,11 @@ jobs:
             - name: Run benchmarks
               run: |
                 mkdir results
-                benchpkg --add https://github.com/LilithHafner/ChairmarksForAirspeedVelocity.jl ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.pull_request.base.sha}},${{github.event.pull_request.head.sha}}" --url=${{ github.event.repository.clone_url }} --bench-on="${{github.event.pull_request.head.sha}}" --output-dir=results/ --tune
+                benchpkg --add https://github.com/LilithHafner/ChairmarksForAirspeedVelocity.jl ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.pull_request.head.sha}},${{github.event.pull_request.base.sha}}" --url=${{ github.event.repository.clone_url }} --bench-on="${{github.event.pull_request.head.sha}}" --output-dir=results/ --tune
             - name: Create plots from benchmarks
               run: |
                 mkdir -p plots
-                benchpkgplot ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.pull_request.base.sha}},${{github.event.pull_request.head.sha}}" --npart=10 --format=png --input-dir=results/ --output-dir=plots/
+                benchpkgplot ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.pull_request.head.sha}},${{github.event.pull_request.base.sha}}" --npart=10 --format=png --input-dir=results/ --output-dir=plots/
             - name: Upload plot as artifact
               uses: actions/upload-artifact@v4
               with:
@@ -50,7 +50,7 @@ jobs:
                 path: plots
             - name: Create markdown table from benchmarks
               run: |
-                benchpkgtable ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.pull_request.base.sha}},${{github.event.pull_request.head.sha}}" --input-dir=results/ --ratio > table.md
+                benchpkgtable ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.pull_request.head.sha}},${{github.event.pull_request.base.sha}}" --input-dir=results/ --ratio > table.md
                 echo '### Benchmark Results' > body.md
                 echo '' >> body.md
                 echo '' >> body.md

--- a/.github/workflows/benchmark_pr_3.yml
+++ b/.github/workflows/benchmark_pr_3.yml
@@ -38,11 +38,11 @@ jobs:
             - name: Run benchmarks
               run: |
                 mkdir results
-                benchpkg --add https://github.com/LilithHafner/ChairmarksForAirspeedVelocity.jl ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.pull_request.base.sha}},${{github.event.pull_request.head.sha}}" --url=${{ github.event.repository.clone_url }} --bench-on="${{github.event.pull_request.head.sha}}" --output-dir=results/ --tune
+                benchpkg --add https://github.com/LilithHafner/ChairmarksForAirspeedVelocity.jl ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.pull_request.head.sha}},${{github.event.pull_request.base.sha}}" --url=${{ github.event.repository.clone_url }} --bench-on="${{github.event.pull_request.head.sha}}" --output-dir=results/ --tune
             - name: Create plots from benchmarks
               run: |
                 mkdir -p plots
-                benchpkgplot ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.pull_request.base.sha}},${{github.event.pull_request.head.sha}}" --npart=10 --format=png --input-dir=results/ --output-dir=plots/
+                benchpkgplot ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.pull_request.head.sha}},${{github.event.pull_request.base.sha}}" --npart=10 --format=png --input-dir=results/ --output-dir=plots/
             - name: Upload plot as artifact
               uses: actions/upload-artifact@v4
               with:
@@ -50,7 +50,7 @@ jobs:
                 path: plots
             - name: Create markdown table from benchmarks
               run: |
-                benchpkgtable ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.pull_request.base.sha}},${{github.event.pull_request.head.sha}}" --input-dir=results/ --ratio > table.md
+                benchpkgtable ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.pull_request.head.sha}},${{github.event.pull_request.base.sha}}" --input-dir=results/ --ratio > table.md
                 echo '### Benchmark Results' > body.md
                 echo '' >> body.md
                 echo '' >> body.md

--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -1,5 +1,7 @@
 module DynamicDiscreteSamplers
 
+__init__() = sleep(1)
+
 export DynamicDiscreteSampler
 
 using Random


### PR DESCRIPTION
This means higher numbers correspond to increases in runtime, size, etc. and lower numbers decreases. I think this is more intuitive.