### PR TITLE
Remove broadcast assignment in update_significand_sum

### DIFF
--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -306,7 +306,8 @@ end
 function update_significand_sum(m, i, delta)
     j = _convert(Int, 2i+2041)
     significand_sum = get_significand_sum(m, i) + delta
-    m[j:j+1] .= (significand_sum % UInt64, (significand_sum >>> 64) % UInt64)
+    m[j] = significand_sum % UInt64
+    m[j+1] = (significand_sum >>> 64) % UInt64
     significand_sum
 end
 


### PR DESCRIPTION
Not sure it is noticeable in our benchmarks, but by profiling I noticed it added a tiny overhead