### PR TITLE
Use total length to shrink ranges for approximate weights recomputations

### DIFF
--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -487,16 +487,18 @@ function set_global_shift_increase!(m::Memory, m2, m3::UInt64, m4) # Increase sh
     weight = UInt64(significand_sum<<shift) + 1
     when is that always 1? when
     UInt64(significand_sum<<shift) == 0
-    and because shift < 0 and significand_sum could be as much as 2^64*2^64/8/8-1 = 2^122-1,
-    shift <= -122
+
+    and because shift < 0 and significand_sum could be as much as (exponent(m1)+1)*2^64-1,
+    shift <= -(exponent(m1)+1)-64
     shift = signed(exponent+m3)
     shift = signed(i-4+m3)
-    signed(i-4+m3) <= -122
-    i <= -signed(m3)-122+4
-    So for -signed(m3)-118 < i, we could need to adjust the ith weight
+    signed(i-4+m3) <= -(exponent(m1)+1)-64
+    i <= -signed(m3)-(exponent(m1)+1)-64+4
+    So for -signed(m3)-61-exponent(m1) < i, we could need to adjust the ith weight
     =#
-    r0 = max(5, -signed(m3)-117)
-    r1 = m2 # TODO It would be possible to scale this range with length (m[1]) in which case testing could be stricter and performance could be (marginally) better, though not in large cases so possibly not worth doing at all)
+    expm1 = exponent(m[1])
+    r0 = max(5, -signed(m3)-61-expm1)
+    r1 = m2
 
     # shift = signed(i-4+m3)
     # weight = significand_sum == 0 ? 0 : UInt64(significand_sum << shift) + 1
@@ -531,13 +533,14 @@ function set_global_shift_decrease!(m::Memory, m3::UInt64, m4=m[4]) # Decrease s
     # from the first index that previously could have had a weight > 1 to min(m[2], the first index that can't have a weight > 1) (never empty), set weights to 1 or 0
     # from the first index that could have a weight > 1 to m[2] (possibly empty), shift weights by delta.
     m2 = signed(m[2])
-    i1 = -signed(m3)-117 # see above, this is the first index that could have weight > 1 (anything after this will have weight 1 or 0)
-    i1_old = -signed(m3_old)-117 # anything before this is already weight 1 or 0
+    expm1 = exponent(m[1])
+    i1 = -signed(m3)-61-expm1 # see above, this is the first index that could have weight > 1 (anything after this will have weight 1 or 0)
+    i1_old = -signed(m3_old)-61-expm1 # anything before this is already weight 1 or 0
     flatten_range = max(i1_old, 5):min(m2, i1-1)
     recompute_range = max(i1, 5):m2
     # From the level where one element contributes 2^64 to the level where one element contributes 1 is 64, and from there to the level where 2^64 elements contributes 1 is another 2^64.
-    @assert length(flatten_range) <= 128
-    @assert length(recompute_range) <= 128
+    @assert length(flatten_range) <= 64+expm1+1+1
+    @assert length(recompute_range) <= 64+expm1+1+1
 
     checkbounds(m, flatten_range)
     @inbounds for i in flatten_range # set nonzeros to 1


### PR DESCRIPTION
This improves the pathological' cases. I have to say that I'm not sure this is fully correct, so review with care.