### PR TITLE
Support FixedSizeWeights([1,2,3])

### DIFF
--- a/src/DynamicDiscreteSamplers.jl
+++ b/src/DynamicDiscreteSamplers.jl
@@ -797,6 +797,15 @@ end
 # Conform to the AbstractArray API
 Base.size(w::Weights) = (w.m[1],)
 
+# Define convinience constructors TODO: these can be significantly optimized, especially when `x isa Weights`
+function (::Type{T})(x::AbstractVector{<:Real}) where {T <: Weights}
+    w = T(length(x))
+    for (i, v) in enumerate(x)
+        w[i] = v
+    end
+    w
+end
+
 # Precompile
 precompile(ResizableWeights, (Int,))
 precompile(length, (ResizableWeights,))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,12 @@ using StatsBase
 
 @test DynamicDiscreteSamplers.DEBUG === true
 
+@testset "Constructor from array" begin
+    w = FixedSizeWeights([1.7,2.9])
+    @test w isa FixedSizeWeights
+    @test w == [1.7, 2.9]
+end
+
 function ensure_sampler_conforms_to_rng_api(source, domain)
     # Conventional usage
     let x = rand(source)

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -217,12 +217,10 @@ verify(w.m)
 w = DynamicDiscreteSamplers.FixedSizeWeights(10)
 @test_throws MethodError resize!(w, 20)
 @test_throws MethodError resize!(w, 5)
-function mutate_immutable(w)
-    w2 = DynamicDiscreteSamplers.SemiResizableWeights(w) # This previously worked
-    resize!(w2, 5)
-end
-@test_throws Exception mutate_immutable(w)
-@test length(w) == 10 # This fails if the above line worked
+w2 = DynamicDiscreteSamplers.SemiResizableWeights(w)
+resize!(w2, 5)
+@test length(w2) == 5
+@test length(w) == 10 # The fixed size has not changed
 
 w = DynamicDiscreteSamplers.FixedSizeWeights(9)
 v = zeros(9)


### PR DESCRIPTION
Using the naive implementation of repeated `setindex!`

The mutating immutable test no longer throws, but it still doesn't mutate the immutable.