### PR TITLE
Rename package from DynamicDiscreteSamplers to WeightVectors

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,6 +74,6 @@ jobs:
         shell: julia --project=docs --color=yes {0}
         run: |
           using Documenter: DocMeta, doctest
-          using DynamicDiscreteSamplers
-          DocMeta.setdocmeta!(DynamicDiscreteSamplers, :DocTestSetup, :(using DynamicDiscreteSamplers); recursive=true)
-          doctest(DynamicDiscreteSamplers)
+          using WeightVectors
+          DocMeta.setdocmeta!(WeightVectors, :DocTestSetup, :(using WeightVectors); recursive=true)
+          doctest(WeightVectors)

--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "DynamicDiscreteSamplers"
+name = "WeightVectors"
 uuid = "02edb123-fbf3-4025-abe6-bed5b7376cdf"
 authors = ["Lilith Orion Hafner <lilithhafner@gmail.com>, Adriano Meligrana <adrianomeligrana@proton.me> and contributors"]
 version = "0.0.0"

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# DynamicDiscreteSamplers
+# WeightVectors
 
-<!-- [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://LilithHafner.github.io/DynamicDiscreteSamplers.jl/stable/) -->
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://LilithHafner.github.io/DynamicDiscreteSamplers.jl/dev/)
-[![Build Status](https://github.com/LilithHafner/DynamicDiscreteSamplers.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/LilithHafner/DynamicDiscreteSamplers.jl/actions/workflows/CI.yml?query=branch%3Amain)
-[![Coverage](https://codecov.io/gh/LilithHafner/DynamicDiscreteSamplers.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/LilithHafner/DynamicDiscreteSamplers.jl) <!--
-[![PkgEval](https://JuliaCI.github.io/NanosoldierReports/pkgeval_badges/D/DynamicDiscreteSamplers.svg)](https://JuliaCI.github.io/NanosoldierReports/pkgeval_badges/D/DynamicDiscreteSamplers.html) -->
+<!-- [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://LilithHafner.github.io/WeightVectors.jl/stable/) -->
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://LilithHafner.github.io/WeightVectors.jl/dev/)
+[![Build Status](https://github.com/LilithHafner/WeightVectors.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/LilithHafner/WeightVectors.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![Coverage](https://codecov.io/gh/LilithHafner/WeightVectors.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/LilithHafner/WeightVectors.jl) <!--
+[![PkgEval](https://JuliaCI.github.io/NanosoldierReports/pkgeval_badges/W/WeightVectors.svg)](https://JuliaCI.github.io/NanosoldierReports/pkgeval_badges/W/WeightVectors.html) -->
 [![Aqua](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
-`DynamicDiscreteSamplers.jl` implements efficient samplers which can be used to sample from a dynamic discrete distribution, supporting removal, addition and sampling of elements in constant time. 
+`WeightVectors.jl` implements efficient samplers which can be used to sample from a dynamic discrete distribution, supporting removal, addition and sampling of elements in constant time.
 
 The key features of this package are
 
@@ -20,16 +20,16 @@ The key features of this package are
 
 The package exports two main types which conform to the `AbstractArray` API:
 
-- `FixedSizeWeights`: For a static collection of weights which can be updated but not resized;
-- `ResizableWeights`: For a collection of weights which can grow or shrink.
+- `FixedSizeWeightVector`: For a static collection of weights which can be updated but not resized;
+- `WeightVector`: For a collection of weights which can grow or shrink.
 
 ```julia
-julia> using Random, DynamicDiscreteSamplers
+julia> using Random, WeightVectors
 
 julia> rng = Xoshiro(42);
 
-julia> w = ResizableWeights([10.0, 50.0, 5.0, 35.0])
-4-element ResizableWeights:
+julia> w = WeightVector([10.0, 50.0, 5.0, 35.0])
+4-element WeightVector:
  10.0
  50.0
   5.0

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,5 +1,5 @@
-using DynamicDiscreteSamplers
-using DynamicDiscreteSamplers: FixedSizeWeights, ResizableWeights, SemiResizableWeights # compat with older versions of DynamicDiscreteSamplers.jl
+using WeightVectors
+using WeightVectors: FixedSizeWeightVector, WeightVector, SemiResizableWeightVector # compat with older versions of WeightVectors.jl
 using Random
 include("../test/DynamicDiscreteSampler.jl")
 
@@ -206,7 +206,7 @@ end
 SUITE["pathological 5b′′"] = @benchmarkable pathological5b′′_setup pathological5b′′_update
 
 function pathological_compaction_setup()
-    w = FixedSizeWeights(2^20+1)
+    w = FixedSizeWeightVector(2^20+1)
     w[1:2^19] .= 1
     w[2^19+1:2^20] .= 2
     pathological_compaction_update!(w)
@@ -220,7 +220,7 @@ end
 SUITE["pathological compaction"] = @benchmarkable pathological_compaction_setup pathological_compaction_update!
 
 include("code_size.jl")
-_code_size = code_size(dirname(pathof(DynamicDiscreteSamplers)))
+_code_size = code_size(dirname(pathof(WeightVectors)))
 
 SUITE["code size in lines"] = constant(3600_code_size.lines)
 SUITE["code size in bytes"] = constant(3600_code_size.bytes)

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,3 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-DynamicDiscreteSamplers = "02edb123-fbf3-4025-abe6-bed5b7376cdf"
+WeightVectors = "02edb123-fbf3-4025-abe6-bed5b7376cdf"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,14 +1,14 @@
-using DynamicDiscreteSamplers
+using WeightVectors
 using Documenter
 
-DocMeta.setdocmeta!(DynamicDiscreteSamplers, :DocTestSetup, :(using DynamicDiscreteSamplers); recursive=true)
+DocMeta.setdocmeta!(WeightVectors, :DocTestSetup, :(using WeightVectors); recursive=true)
 
 makedocs(;
-    modules=[DynamicDiscreteSamplers],
+    modules=[WeightVectors],
     authors="Lilith Orion Hafner <lilithhafner@gmail.com> and contributors",
-    sitename="DynamicDiscreteSamplers.jl",
+    sitename="WeightVectors.jl",
     format=Documenter.HTML(;
-        canonical="https://LilithHafner.github.io/DynamicDiscreteSamplers.jl",
+        canonical="https://LilithHafner.github.io/WeightVectors.jl",
         edit_link="main",
         assets=String[],
     ),
@@ -18,6 +18,6 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/LilithHafner/DynamicDiscreteSamplers.jl",
+    repo="github.com/LilithHafner/WeightVectors.jl",
     devbranch="main",
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,14 +1,14 @@
 ```@meta
-CurrentModule = DynamicDiscreteSamplers
+CurrentModule = WeightVectors
 ```
 
-# DynamicDiscreteSamplers
+# WeightVectors
 
-Documentation for [DynamicDiscreteSamplers](https://github.com/LilithHafner/DynamicDiscreteSamplers.jl).
+Documentation for [WeightVectors](https://github.com/LilithHafner/WeightVectors.jl).
 
 ```@index
 ```
 
 ```@autodocs
-Modules = [DynamicDiscreteSamplers]
+Modules = [WeightVectors]
 ```

--- a/test/DynamicDiscreteSampler.jl
+++ b/test/DynamicDiscreteSampler.jl
@@ -1,8 +1,8 @@
 # Shoe-horn into the legacy DynamicDiscreteSampler API so that we can leverage legacy tests and benchmarks
 struct WeightBasedSampler
-    w::ResizableWeights
+    w::WeightVector
 end
-WeightBasedSampler() = WeightBasedSampler(ResizableWeights(512))
+WeightBasedSampler() = WeightBasedSampler(WeightVector(512))
 
 function Base.push!(wbs::WeightBasedSampler, index, weight)
     index > length(wbs.w) && resize!(wbs.w, max(index, 2length(wbs.w)))

--- a/test/DynamicDiscreteSampler_tests.jl
+++ b/test/DynamicDiscreteSampler_tests.jl
@@ -204,7 +204,7 @@ end
 error_d03fb() # This threw AssertionError: 48 <= Base.top_set_bit(m[4]) <= 50 90% of the time on d03fb84d1b62272c5d6ab54c49e643af9b87201b
 
 function error_d03fb_2(n)
-    w = DynamicDiscreteSamplers.FixedSizeWeights(2^n+1);
+    w = WeightVectors.FixedSizeWeightVector(2^n+1);
     for i in 1:2^n-1
         w[i] = .99*.5^Base.top_set_bit(i)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using DynamicDiscreteSamplers
+using WeightVectors
 using HypothesisTests
 using Random
 using Test
@@ -6,11 +6,11 @@ using Aqua
 using StableRNGs
 using StatsBase
 
-@test DynamicDiscreteSamplers.DEBUG === true
+@test WeightVectors.DEBUG === true
 
 @testset "Constructor from array" begin
-    w = FixedSizeWeights([1.7,2.9])
-    @test w isa FixedSizeWeights
+    w = FixedSizeWeightVector([1.7,2.9])
+    @test w isa FixedSizeWeightVector
     @test w == [1.7, 2.9]
 end
 
@@ -70,13 +70,13 @@ function ensure_sampler_conforms_to_rng_api(source, domain)
         end
     end
 end
-w = DynamicDiscreteSamplers.FixedSizeWeights(2)
+w = WeightVectors.FixedSizeWeightVector(2)
 w[1] = 1.0
 w[2] = 2.0
 ensure_sampler_conforms_to_rng_api(w, 1:2)
 
 @testset "unsigned int construction" begin
-    @test length(FixedSizeWeights(UInt(10))) == 10
+    @test length(FixedSizeWeightVector(UInt(10))) == 10
 end
 
 include("DynamicDiscreteSampler_tests.jl") # Indirect tests for an upstream usage/legacy API
@@ -84,8 +84,8 @@ include("DynamicDiscreteSampler_tests.jl") # Indirect tests for an upstream usag
 # These tests are too slow:
 if "CI" in keys(ENV)
     @testset "Code quality (Aqua.jl)" begin
-        Aqua.test_all(DynamicDiscreteSamplers, deps_compat=false)
-        Aqua.test_deps_compat(DynamicDiscreteSamplers, check_extras=false)
+        Aqua.test_all(WeightVectors, deps_compat=false)
+        Aqua.test_deps_compat(WeightVectors, check_extras=false)
     end
 end
 

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -1,10 +1,10 @@
-using DynamicDiscreteSamplers, Test
+using WeightVectors, Test
 
-@test DynamicDiscreteSamplers.FixedSizeWeights(10) isa DynamicDiscreteSamplers.FixedSizeWeights
-@test DynamicDiscreteSamplers.ResizableWeights(10) isa DynamicDiscreteSamplers.ResizableWeights
-@test DynamicDiscreteSamplers.SemiResizableWeights(10) isa DynamicDiscreteSamplers.SemiResizableWeights
+@test WeightVectors.FixedSizeWeightVector(10) isa WeightVectors.FixedSizeWeightVector
+@test WeightVectors.WeightVector(10) isa WeightVectors.WeightVector
+@test WeightVectors.SemiResizableWeightVector(10) isa WeightVectors.SemiResizableWeightVector
 
-w = DynamicDiscreteSamplers.FixedSizeWeights(10)
+w = WeightVectors.FixedSizeWeightVector(10)
 
 @test_throws ArgumentError("collection must be non-empty") rand(w)
 
@@ -36,7 +36,7 @@ for i in 1:10
 end
 @test iszero(w) == true
 
-w = DynamicDiscreteSamplers.FixedSizeWeights(10)
+w = WeightVectors.FixedSizeWeightVector(10)
 w[1] = 3
 w[2] = 2
 w[3] = 3
@@ -44,7 +44,7 @@ w[3] = 3
 @test w[2] == 2
 @test w[3] == 3
 
-w = DynamicDiscreteSamplers.FixedSizeWeights(10)
+w = WeightVectors.FixedSizeWeightVector(10)
 w[9] = 3
 w[7] = 3
 w[1] = 3
@@ -52,7 +52,7 @@ w[1] = 3
 @test w[7] == 3
 @test w[1] == 3
 
-w = DynamicDiscreteSamplers.FixedSizeWeights(10)
+w = WeightVectors.FixedSizeWeightVector(10)
 w[8] = 0.549326222415666
 w[6] = 1.0149666786255531
 w[3] = 0.8210275222825218
@@ -60,7 +60,7 @@ w[3] = 0.8210275222825218
 @test w[6] === 1.0149666786255531
 @test w[3] === 0.8210275222825218
 
-w = DynamicDiscreteSamplers.FixedSizeWeights(10)
+w = WeightVectors.FixedSizeWeightVector(10)
 w[8] = 3.2999782300326728
 w[9] = 0.7329714939310719
 w[3] = 2.397108987310203
@@ -68,20 +68,20 @@ w[3] = 2.397108987310203
 @test w[9] === 0.7329714939310719
 @test w[3] === 2.397108987310203
 
-w = DynamicDiscreteSamplers.FixedSizeWeights(10)
+w = WeightVectors.FixedSizeWeightVector(10)
 w[1] = 1.5
 w[2] = 1.6
 w[1] = 1.7
 @test w[1] === 1.7
 @test w[2] === 1.6
 
-w = DynamicDiscreteSamplers.FixedSizeWeights(10)
+w = WeightVectors.FixedSizeWeightVector(10)
 w[1] = 1
 w[2] = 1e8
 @test w[1] == 1
 @test w[2] === 1e8
 
-let w = DynamicDiscreteSamplers.FixedSizeWeights(2)
+let w = WeightVectors.FixedSizeWeightVector(2)
     w[1] = 1.1
     w[2] = 1.9
     twos = 0
@@ -99,18 +99,18 @@ let w = DynamicDiscreteSamplers.FixedSizeWeights(2)
     @test abs(twos-expected) < 4stdev
 end
 
-let w = DynamicDiscreteSamplers.FixedSizeWeights(10)
+let w = WeightVectors.FixedSizeWeightVector(10)
     for i in 1:40
         w[1] = 1.5*2.0^i
         @test w[1] === 1.5*2.0^i
     end
 end
 
-w = DynamicDiscreteSamplers.ResizableWeights(10)
+w = WeightVectors.WeightVector(10)
 resize!(w, 20)
 resize!(w, unsigned(30))
 
-w = DynamicDiscreteSamplers.ResizableWeights(10)
+w = WeightVectors.WeightVector(10)
 w[5] = 3
 resize!(w, 20)
 v = fill(0.0, 20)
@@ -121,20 +121,20 @@ v[5] = 3
 w[11] = v[11] = 3.5
 @test w == v
 
-w = DynamicDiscreteSamplers.ResizableWeights(10)
+w = WeightVectors.WeightVector(10)
 w[1] = 1.2
 w[1] = 0
 resize!(w, 20)
 w[15] = 1.3
 @test w[11] == 0
 
-w = DynamicDiscreteSamplers.ResizableWeights(10)
+w = WeightVectors.WeightVector(10)
 w[1] = 1.2
 w[2] = 1.3
 w[2] = 0
 resize!(w, 20)
 
-w = DynamicDiscreteSamplers.ResizableWeights(10)
+w = WeightVectors.WeightVector(10)
 w[5] = 1.2
 w[6] = 1.3
 w[6] = 0
@@ -144,13 +144,13 @@ resize!(w, 40)
 w[30] = 4.1
 w[22] = 2.2 # This previously threw
 
-w = DynamicDiscreteSamplers.ResizableWeights(10);
+w = WeightVectors.WeightVector(10);
 w[5] = 1.5
 resize!(w, 3)
 resize!(w, 20) # This previously threw
 @test w == fill(0.0, 20)
 
-w = DynamicDiscreteSamplers.ResizableWeights(2)
+w = WeightVectors.WeightVector(2)
 w[1] = .3
 w[2] = 1.1
 w[2] = .4
@@ -159,7 +159,7 @@ w[1] = .6
 w[2] = .7 # This used to throw
 @test w == [.6, .7]
 
-w = DynamicDiscreteSamplers.ResizableWeights(1)
+w = WeightVectors.WeightVector(1)
 w[1] = 18
 w[1] = .9
 w[1] = 1.3
@@ -169,7 +169,7 @@ w[1] = .9
 resize!(w, 2)
 @test w == [.9, 0]
 
-w = DynamicDiscreteSamplers.ResizableWeights(2)
+w = WeightVectors.WeightVector(2)
 w[2] = 19
 w[2] = 10
 w[2] = .9
@@ -178,7 +178,7 @@ w[1] = 1.1
 w[1] = 0.7
 @test w == [.7, .9]
 
-w = DynamicDiscreteSamplers.ResizableWeights(6)
+w = WeightVectors.WeightVector(6)
 resize!(w, 2108)
 w[296] = 3.686559798150465e39
 w[296] = 0
@@ -199,7 +199,7 @@ w[1939] = 7.075668919342077e18
 w[979] = 0.8922993294513122
 resize!(w, 1612) # This previously threw an AssertionError: 48 <= Base.top_set_bit(m[4]) <= 49
 
-w = DynamicDiscreteSamplers.FixedSizeWeights(10)
+w = WeightVectors.FixedSizeWeightVector(10)
 for x in (floatmin(Float64), prevfloat(1.0, 2), prevfloat(1.0), 1.0, nextfloat(1.0), nextfloat(1.0, 2), floatmax(Float64))
     w[1] = x # This previously threw on prevfloat(1.0) and floatmax(Float64)
     @test w[1] === x
@@ -207,13 +207,13 @@ end
 
 include("invariants.jl")
 
-w = DynamicDiscreteSamplers.ResizableWeights(31)
+w = WeightVectors.WeightVector(31)
 w[11] = 9.923269000574892e-8
 w[23] = 0.9876032886161744
 w[31] = 1.1160998022859043
 verify(w.m)
 
-w = DynamicDiscreteSamplers.FixedSizeWeights(10)
+w = WeightVectors.FixedSizeWeightVector(10)
 w[1] = floatmin(Float64)
 w[2] = floatmax(Float64)
 w[2] = 0 # This previously threw an assertion error due to overflow when estimating sum of level weights
@@ -222,16 +222,16 @@ w[1] = eps(0.0)
 @test w[1] == eps(0.0)
 verify(w.m)
 
-# Confirm that FixedSizeWeights cannot be resized:
-w = DynamicDiscreteSamplers.FixedSizeWeights(10)
+# Confirm that FixedSizeWeightVector cannot be resized:
+w = WeightVectors.FixedSizeWeightVector(10)
 @test_throws MethodError resize!(w, 20)
 @test_throws MethodError resize!(w, 5)
-w2 = DynamicDiscreteSamplers.SemiResizableWeights(w)
+w2 = WeightVectors.SemiResizableWeightVector(w)
 resize!(w2, 5)
 @test length(w2) == 5
 @test length(w) == 10 # The fixed size has not changed
 
-w = DynamicDiscreteSamplers.FixedSizeWeights(9)
+w = WeightVectors.FixedSizeWeightVector(9)
 v = zeros(9)
 v[4] = w[4] = 2.44
 v[5] = w[5] = 0.76
@@ -253,13 +253,13 @@ v[3] = w[3] = 0.92
 verify(w.m)
 @test v == w
 
-w = DynamicDiscreteSamplers.ResizableWeights(2)
+w = WeightVectors.WeightVector(2)
 w[1] = 0.95
 w[2] = 6.41e14
 verify(w.m)
 
 # This test catches a bug that was not revealed by the RNG tests below
-w = DynamicDiscreteSamplers.FixedSizeWeights(3);
+w = WeightVectors.FixedSizeWeightVector(3);
 w[1] = 1.5
 w[2] = prevfloat(1.5)
 w[3] = 2^25
@@ -268,7 +268,7 @@ verify(w.m)
 # This test catches a bug that was not revealed by the RNG tests below.
 # The final line is calibrated to have about a 50% fail rate on that bug
 # and run in about 3 seconds:
-w = DynamicDiscreteSamplers.FixedSizeWeights(2046*2048)
+w = WeightVectors.FixedSizeWeightVector(2046*2048)
 w .= repeat(ldexp.(1.0, -1022:1023), inner=2048)
 w[(2046-16)*2048+1:2046*2048] .= 0
 @test w.m[4] < 2.0^32*1.1 # Confirm that we created an interesting condition
@@ -277,7 +277,7 @@ verify(w.m)
 @test f(w, 2^27) ≈ 4.1543685e6*2^27 rtol=1e-6 # This should fail less than 1e-40 of the time
 
 # These tests have never revealed a bug that was not revealed by one of the above tests:
-w = DynamicDiscreteSamplers.FixedSizeWeights(10)
+w = WeightVectors.FixedSizeWeightVector(10)
 w[1] = 1
 w[2] = 1e100
 @test rand(w) === 2
@@ -292,7 +292,7 @@ w[3] = 0
 
 let
     for _ in 1:10000
-        w = DynamicDiscreteSamplers.FixedSizeWeights(10)
+        w = WeightVectors.FixedSizeWeightVector(10)
         v = [w[i] for i in 1:10]
         for _ in 1:10
             i = rand(1:10)
@@ -317,7 +317,7 @@ try
             global LOG = []
             len = rand(1:100)
             push!(LOG, len)
-            w = DynamicDiscreteSamplers.ResizableWeights(len)
+            w = WeightVectors.WeightVector(len)
             v = fill(0.0, len)
             resize = rand(Bool) # Some behavior emerges when not resizing for a long period
             for _ in 1:rand((10,100,3000))
@@ -367,7 +367,7 @@ catch
     println("Reproducer:\n```julia")
     for L in LOG
         if L isa Int
-            println("w = DynamicDiscreteSamplers.ResizableWeights($L)")
+            println("w = WeightVectors.WeightVector($L)")
         elseif first(L) === resize!
             println("resize!(w, $(last(L)))")
         else


### PR DESCRIPTION
This follows the naming convention [#3 in here](https://pkgdocs.julialang.org/v1/creating-packages/#Package-naming-rules), is reasonably short, and each word is essential and very informative. `Vector` tells users that this type follows the basic `Vector` API which is critical information when using the type. `Weight` as used in `WeightVector` indicates that the vector's elements are, themselves, weights, which is critical information for understanding that `rand(x::WeightVector)` draws an index according to the values stored in `x`.

Further, it follows the `Array`/`FixedSizeArray` pattern.

Once this merges, I'll rename the git repo.