### PR TITLE
Adjust refinement process in sampling to reject in edge case

### DIFF
--- a/src/WeightVectors.jl
+++ b/src/WeightVectors.jl
@@ -279,7 +279,6 @@ function _rand_slow_path(rng::AbstractRNG, m::Memory{UInt64}, i)
         target = (significand_sum << shift) % UInt64
         x > target && return true
         x < target && return false
-        shift >= 0 && return false
     end
 end
 

--- a/src/WeightVectors.jl
+++ b/src/WeightVectors.jl
@@ -279,6 +279,7 @@ function _rand_slow_path(rng::AbstractRNG, m::Memory{UInt64}, i)
         target = (significand_sum << shift) % UInt64
         x > target && return true
         x < target && return false
+        shift >= 0 && return true
     end
 end
 


### PR DESCRIPTION
I think returning `false` in the case all bits match is wrong, since in that case the event in which the index is actually accepted has probability 0 since further refinement will certainly reject.

I fixed this by removing the condition, another way to fix this is to return `true` in that case.