### PR TITLE
Bound better the loop size for the estimator to increase the shift

### DIFF
--- a/src/WeightVectors.jl
+++ b/src/WeightVectors.jl
@@ -485,7 +485,7 @@ function set_global_shift_increase!(m::Memory{UInt64}, m5)
     checkbounds(m, offset-65*2:offset-2)
 
     # This can underflow from significand sums into weights, but that underflow is safe because it can only happen if all the latter weights are zero. Be careful about this when re-arranging the memory layout!
-    for i in 1:(Base.top_set_bit(m[4])+1)
+    for i in (Base.top_set_bit(m[4])+1):-1:1
         @inbounds x += m[offset - 2i] >> (i - 2)
     end
 

--- a/src/WeightVectors.jl
+++ b/src/WeightVectors.jl
@@ -485,7 +485,7 @@ function set_global_shift_increase!(m::Memory{UInt64}, m5)
     checkbounds(m, offset-65*2:offset-2)
 
     # This can underflow from significand sums into weights, but that underflow is safe because it can only happen if all the latter weights are zero. Be careful about this when re-arranging the memory layout!
-    for i in (Base.top_set_bit(m[4])+1):-1:1
+    for i in 1:(Base.top_set_bit(m[4])+1)
         @inbounds x += m[offset - 2i] >> (i - 2)
     end
 

--- a/src/WeightVectors.jl
+++ b/src/WeightVectors.jl
@@ -484,9 +484,10 @@ function set_global_shift_increase!(m::Memory{UInt64}, m5)
     offset = 2m2+2093+2
     checkbounds(m, offset-65*2:offset-2)
 
-    # TODO for perf, we can get away with shaving 1 to 10 off of these operations.
     # This can underflow from significand sums into weights, but that underflow is safe because it can only happen if all the latter weights are zero. Be careful about this when re-arranging the memory layout!
-    Base.Cartesian.@nexprs 65 i -> (@inbounds x += m[offset - 2i] >> (i - 2))
+    for i in 1:(Base.top_set_bit(m[4])+1)
+        @inbounds x += m[offset - 2i] >> (i - 2)
+    end
 
     # x is computed by rounding down at a certain level and then summing (and adding 1)
     # m[5] will be computed by rounding up at a more precise level and then summing


### PR DESCRIPTION
This should be okay since `significand_sum_hi < group_length <= m[4]`